### PR TITLE
Honor Codex rate-limit retry delays

### DIFF
--- a/packages/fold-codex/src/CodexModel.ts
+++ b/packages/fold-codex/src/CodexModel.ts
@@ -9,9 +9,9 @@
  * terminal `response.completed`/`response.incomplete` event's response, because the backend rejects
  * `stream: false` outright. SSE is the transport: stateless full-input requests with no response-id
  * chaining, so every retry is a clean re-send; the WebSocket alternate is a config flag that lands
- * with the CLI (D23 amendment). Connection-level flakiness (connect errors, 408/429/5xx) retries at
- * the HttpClient seam via `retryTransient`, below the auth header injection so retries never re-enter
- * the auth path.
+ * with the CLI (D23 amendment). Transport failures retry at the HttpClient seam below the auth header
+ * injection so retries never re-enter the auth path. Retryable provider responses, including 429,
+ * retry before the first stream event and honor the provider's Retry-After delay.
  */
 import { OpenAiClient, OpenAiLanguageModel } from '@effect/ai-openai'
 import * as OpenAiSchema from '@effect/ai-openai/OpenAiSchema'
@@ -32,7 +32,7 @@ import {
 	CODEX_ERROR_MODULE,
 	codexAcquisitionStallError,
 	defaultCodexHardening,
-	isCodexFirstEventStall,
+	isCodexRetryableBeforeFirstEvent,
 	withFirstEventRetry,
 	withStallTimeouts,
 } from './Hardening'
@@ -40,7 +40,7 @@ import {
 /** The ChatGPT Codex backend the provider talks to (the client appends `/responses`). */
 export const CODEX_API_URL = 'https://chatgpt.com/backend-api/codex'
 
-/** Default `retryTransient` attempts for connection-level failures on model requests. */
+/** Default `retryTransient` attempts for transport failures on model requests. */
 export const DEFAULT_REQUEST_RETRY_TIMES = 3
 
 /** The codex model used when {@link CodexModelOptions.model} is omitted. */
@@ -111,11 +111,14 @@ type ResponseFold = {
  */
 export const decorateCodexClient = (inner: OpenAiClient.Service, options: CodexRetryOptions): OpenAiClient.Service => {
 	// `min` caps the infinite exponential delay; `max` intersects it with the finite retry counter.
-	const retrySchedule = Schedule.min([
+	const retryDelaySchedule: Schedule.Schedule<Duration.Duration, AiError.AiError> = Schedule.min([
 		Schedule.exponential(Duration.millis(options.firstEventRetryBaseDelayMs)),
 		Schedule.spaced(Duration.millis(options.firstEventRetryMaxDelayMs)),
 	]).pipe(Schedule.jittered, (schedule) =>
 		Schedule.max([schedule, Schedule.recurs(options.firstEventTimeoutRetries)]),
+	)
+	const retrySchedule = Schedule.passthrough(retryDelaySchedule).pipe(
+		Schedule.modifyDelay(({ output, duration }) => Effect.succeed(output.retryAfter ?? duration)),
 	)
 
 	// One request attempt, bounded by the first-event timeout: a request that gets no response at all
@@ -134,10 +137,10 @@ export const decorateCodexClient = (inner: OpenAiClient.Service, options: CodexR
 	): Effect.Effect<readonly [HttpClientResponse.HttpClientResponse, EventStream], AiError.AiError> => {
 		const transformed = liftLeadingSystemIntoInstructions(payload)
 
-		// Attempt 0 acquires eagerly (its HttpClientResponse is the tuple's response); acquisition
-		// stalls retry in-effect - nothing has streamed yet, so a re-send cannot duplicate anything.
+		// Attempt 0 acquires eagerly (its HttpClientResponse is the tuple's response); retryable acquisition
+		// failures retry in-effect - nothing has streamed yet, so a re-send cannot duplicate anything.
 		return acquireOnce(transformed).pipe(
-			Effect.retry({ while: isCodexFirstEventStall, schedule: retrySchedule }),
+			Effect.retry({ while: isCodexRetryableBeforeFirstEvent, schedule: retrySchedule }),
 			Effect.map(([response, firstStream]) => {
 				let pending: EventStream | null = firstStream
 
@@ -223,7 +226,7 @@ export type CodexModelOptions = {
 	readonly store?: CodexAuthStore
 	/** Identity headers (`originator`/`User-Agent`/`session_id`) sent on model requests. */
 	readonly identity?: CodexIdentityOptions
-	/** Connection-level `retryTransient` attempts. Defaults to {@link DEFAULT_REQUEST_RETRY_TIMES}. */
+	/** Maximum transport retry attempts. Provider response retries use {@link CodexHardeningOptions.firstEventTimeoutRetries}. */
 	readonly requestRetryTimes?: number
 	/** Stall timeout / retry overrides. Defaults to {@link defaultCodexHardening}. */
 	readonly hardening?: Partial<CodexHardeningOptions>
@@ -247,11 +250,15 @@ export const makeCodexLanguageModel = (
 			Effect.provideService(HttpClient.HttpClient, baseClient),
 		)
 
-		// retryTransient sits below the auth wrapper: connection retries reuse the injected headers and
-		// never re-enter (or retry) the auth path itself.
+		// retryTransient sits below the auth wrapper: transport retries reuse the injected headers and never
+		// re-enter (or retry) the auth path itself. Status responses are mapped to AiError above this seam,
+		// where the first-event retry can honor a provider Retry-After rather than retrying a 429 immediately.
 		const modelClient = withCodexAuth(
 			baseClient.pipe(
-				HttpClient.retryTransient({ times: options.requestRetryTimes ?? DEFAULT_REQUEST_RETRY_TIMES }),
+				HttpClient.retryTransient({
+					retryOn: 'errors-only',
+					times: options.requestRetryTimes ?? DEFAULT_REQUEST_RETRY_TIMES,
+				}),
 			),
 			auth,
 			options.identity,

--- a/packages/fold-codex/src/Hardening.ts
+++ b/packages/fold-codex/src/Hardening.ts
@@ -2,11 +2,12 @@
  * Stream hardening for the unstable Codex backend (D23): a first-event ("no headers/no first token")
  * timeout, an idle-without-productive-event timeout, and bounded jittered-exponential retry of
  * first-event stalls. Semantics and defaults are ported from agentlayer's SSE vendor route: only
- * first-event stalls are retried - nothing has been emitted downstream yet, so a silent re-subscribe
- * cannot duplicate content - while an idle stall after partial output fails the stream honestly (the
- * turn-level restart with a `stream-retry` delta is the loop's future integration, D23). Timeouts
- * measure producer latency per pull: the deadline arms when the consumer asks for the next event and
- * clears when one arrives, so consumer-side processing time never counts against the stream.
+ * retryable failures before the first event are retried - nothing has been emitted downstream yet,
+ * so a fresh request cannot duplicate content - while an idle stall after partial output fails the
+ * stream honestly (the turn-level restart with a `stream-retry` delta is the loop's future
+ * integration, D23). Provider RateLimitError values use their Retry-After delay. Timeouts measure
+ * producer latency per pull: the deadline arms when the consumer asks for the next event and clears
+ * when one arrives, so consumer-side processing time never counts against the stream.
  */
 import { Duration, Effect, Random, Stream } from 'effect'
 import { AiError } from 'effect/unstable/ai'
@@ -71,6 +72,14 @@ export const isCodexIdleStall = (error: unknown): error is AiError.AiError =>
 	error instanceof AiError.AiError && error.module === CODEX_ERROR_MODULE && error.method === IDLE_METHOD
 
 /**
+ * A retryable provider failure is safe to repeat only before the model has emitted any stream event.
+ * Mid-stream failures are intentionally excluded because a fresh request could duplicate content or
+ * repeat a tool call that has already reached the agent runtime.
+ */
+export const isCodexRetryableBeforeFirstEvent = (error: unknown): error is AiError.AiError =>
+	error instanceof AiError.AiError && error.isRetryable && !isCodexIdleStall(error)
+
+/**
  * Bound the stream's producer latency: the first event must arrive within `firstEventTimeoutMs` and
  * every later event within `eventIdleTimeoutMs` of the previous pull, or the stream fails with a
  * typed stall error. Firing a timeout interrupts the in-flight pull, which tears down the underlying
@@ -108,7 +117,10 @@ export const withStallTimeouts =
 export const firstEventRetryDelayMs = (
 	options: Pick<CodexHardeningOptions, 'firstEventRetryBaseDelayMs' | 'firstEventRetryMaxDelayMs'>,
 	attempt: number,
+	error?: AiError.AiError,
 ): Effect.Effect<number> => {
+	if (error?.retryAfter !== undefined) return Effect.succeed(Duration.toMillis(error.retryAfter))
+
 	const max = options.firstEventRetryMaxDelayMs
 	const target = Math.min(options.firstEventRetryBaseDelayMs * 2 ** attempt, max)
 
@@ -127,9 +139,10 @@ const defaultOnStreamRetry = (info: StreamRetryInfo): Effect.Effect<void> =>
 	)
 
 /**
- * Retry first-event stalls with bounded jittered-exponential backoff. Each retry re-runs `makeAttempt`
- * from scratch - a fresh subscription and a fresh HTTP request. Only first-event stalls retry; every
- * other failure (idle stalls included) propagates immediately.
+ * Retry retryable failures before the first event with bounded backoff. Each retry re-runs
+ * `makeAttempt` from scratch - a fresh subscription and a fresh HTTP request. A provider-provided
+ * Retry-After takes precedence over the fallback jittered-exponential delay. Every mid-stream failure
+ * propagates immediately.
  */
 export const withFirstEventRetry = <A, E, R>(
 	makeAttempt: () => Stream.Stream<A, E, R>,
@@ -138,18 +151,33 @@ export const withFirstEventRetry = <A, E, R>(
 	const onStreamRetry = options.onStreamRetry ?? defaultOnStreamRetry
 
 	const attempt = (n: number): Stream.Stream<A, E, R> =>
-		makeAttempt().pipe(
-			Stream.catch((error) => {
-				if (!isCodexFirstEventStall(error) || n >= options.firstEventTimeoutRetries) {
-					return Stream.fail(error)
-				}
+		Stream.unwrap(
+			Effect.sync(() => {
+				let emitted = false
 
-				return Stream.unwrap(
-					firstEventRetryDelayMs(options, n).pipe(
-						Effect.tap((delayMs) => onStreamRetry({ attempt: n + 1, delayMs, error })),
-						Effect.flatMap((delayMs) => Effect.sleep(Duration.millis(delayMs))),
-						Effect.map(() => attempt(n + 1)),
+				return makeAttempt().pipe(
+					Stream.tap(() =>
+						Effect.sync(() => {
+							emitted = true
+						}),
 					),
+					Stream.catch((error) => {
+						if (
+							emitted ||
+							!isCodexRetryableBeforeFirstEvent(error) ||
+							n >= options.firstEventTimeoutRetries
+						) {
+							return Stream.fail(error)
+						}
+
+						return Stream.unwrap(
+							firstEventRetryDelayMs(options, n, error).pipe(
+								Effect.tap((delayMs) => onStreamRetry({ attempt: n + 1, delayMs, error })),
+								Effect.flatMap((delayMs) => Effect.sleep(Duration.millis(delayMs))),
+								Effect.map(() => attempt(n + 1)),
+							),
+						)
+					}),
 				)
 			}),
 		)

--- a/packages/fold-codex/test/CodexModel.vi.test.ts
+++ b/packages/fold-codex/test/CodexModel.vi.test.ts
@@ -1,7 +1,8 @@
 import { OpenAiClient } from '@effect/ai-openai'
 import * as OpenAiSchema from '@effect/ai-openai/OpenAiSchema'
 import { describe, expect, it } from '@effect/vitest'
-import { Context, Effect, Layer, Ref, Stream } from 'effect'
+import { Context, Deferred, Duration, Effect, Fiber, Layer, Ref, Stream } from 'effect'
+import { TestClock } from 'effect/testing'
 import { AiError } from 'effect/unstable/ai'
 import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from 'effect/unstable/http'
 
@@ -156,6 +157,50 @@ describe('decorateCodexClient', () => {
 
 			const [payload] = yield* scripted.payloads
 			expect(payload?.instructions).toBe('You are terse.\n\nPrefer bullet points.')
+		}).pipe(Effect.scoped),
+	)
+
+	it.effect('waits for Retry-After before retrying response acquisition', () =>
+		Effect.gen(function* () {
+			const firstAttempt = yield* Deferred.make<void>()
+			const attempts = yield* Ref.make(0)
+			const httpContext = yield* Layer.build(FetchHttpClient.layer)
+			const httpResponse = HttpClientResponse.fromWeb(
+				HttpClientRequest.get('http://scripted.test'),
+				new Response(''),
+			)
+			const rateLimitError = AiError.make({
+				module: 'OpenAiClient',
+				method: 'createResponseStream',
+				reason: new AiError.RateLimitError({ retryAfter: Duration.seconds(16) }),
+			})
+			const service: OpenAiClient.Service = {
+				client: Context.get(httpContext, HttpClient.HttpClient),
+				createResponse: () => Effect.die(new Error('unused')),
+				createResponseStream: () =>
+					Effect.gen(function* () {
+						const attempt = yield* Ref.updateAndGet(attempts, (count) => count + 1)
+						if (attempt === 1) {
+							yield* Deferred.succeed(firstAttempt, undefined)
+							return yield* Effect.fail(rateLimitError)
+						}
+						return [httpResponse, Stream.make(tick('one'))] as const
+					}),
+				createEmbedding: () => Effect.die(new Error('unused')),
+			}
+			const decorated = decorateCodexClient(service, fastOptions())
+			const fiber = yield* decorated
+				.createResponseStream({ model: 'gpt-5.5', input: 'hi' })
+				.pipe(Effect.forkChild({ startImmediately: true }))
+
+			yield* Deferred.await(firstAttempt)
+			yield* TestClock.adjust(Duration.seconds(15))
+			expect(yield* Ref.get(attempts)).toBe(1)
+
+			yield* TestClock.adjust(Duration.seconds(1))
+			const [, stream] = yield* Fiber.join(fiber)
+			expect(yield* Stream.runCollect(stream)).toHaveLength(1)
+			expect(yield* Ref.get(attempts)).toBe(2)
 		}).pipe(Effect.scoped),
 	)
 

--- a/packages/fold-codex/test/Hardening.vi.test.ts
+++ b/packages/fold-codex/test/Hardening.vi.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from '@effect/vitest'
-import { Duration, Effect, Stream } from 'effect'
+import { Deferred, Duration, Effect, Fiber, Stream } from 'effect'
+import { TestClock } from 'effect/testing'
+import { AiError } from 'effect/unstable/ai'
 
 import {
 	firstEventRetryDelayMs,
@@ -122,6 +124,25 @@ describe('hardenCodexStream', () => {
 		}),
 	)
 
+	it.effect('does not retry a rate limit after partial output', () =>
+		Effect.gen(function* () {
+			let attempts = 0
+			const rateLimitError = AiError.make({
+				module: 'test',
+				method: 'streamText',
+				reason: new AiError.RateLimitError({ retryAfter: Duration.millis(1) }),
+			})
+			const stream = hardenCodexStream(() => {
+				attempts += 1
+				return Stream.make(1).pipe(Stream.concat(Stream.fail(rateLimitError)))
+			}, fastOptions())
+
+			const error = yield* Stream.runCollect(stream).pipe(Effect.flip)
+			expect(error).toBe(rateLimitError)
+			expect(attempts).toBe(1)
+		}),
+	)
+
 	it.live('does not retry ordinary provider failures', () =>
 		Effect.gen(function* () {
 			let attempts = 0
@@ -134,6 +155,40 @@ describe('hardenCodexStream', () => {
 			const error = yield* Stream.runCollect(stream).pipe(Effect.flip)
 			expect(error).toBe(boom)
 			expect(attempts).toBe(1)
+		}),
+	)
+
+	it.effect('waits for a provider Retry-After before retrying a rate limit', () =>
+		Effect.gen(function* () {
+			let attempts = 0
+			const firstAttempt = yield* Deferred.make<void>()
+			const retries: Array<StreamRetryInfo> = []
+			const rateLimitError = AiError.make({
+				module: 'test',
+				method: 'streamText',
+				reason: new AiError.RateLimitError({ retryAfter: Duration.seconds(16) }),
+			})
+			const stream = hardenCodexStream(
+				() => {
+					attempts += 1
+					return attempts === 1
+						? Stream.unwrap(
+								Deferred.succeed(firstAttempt, undefined).pipe(Effect.as(Stream.fail(rateLimitError))),
+							)
+						: Stream.make(1)
+				},
+				fastOptions({ onStreamRetry: (info) => Effect.sync(() => void retries.push(info)) }),
+			)
+
+			const fiber = yield* Stream.runCollect(stream).pipe(Effect.forkChild({ startImmediately: true }))
+			yield* Deferred.await(firstAttempt)
+			yield* TestClock.adjust(Duration.seconds(15))
+			expect(attempts).toBe(1)
+
+			yield* TestClock.adjust(Duration.seconds(1))
+			expect(yield* Fiber.join(fiber)).toEqual([1])
+			expect(attempts).toBe(2)
+			expect(retries[0]?.delayMs).toBe(16_000)
 		}),
 	)
 })
@@ -155,6 +210,22 @@ describe('firstEventRetryDelayMs', () => {
 			const capped = yield* firstEventRetryDelayMs(options, 4)
 			expect(capped).toBeGreaterThanOrEqual(8000)
 			expect(capped).toBeLessThanOrEqual(10_000)
+		}),
+	)
+
+	it.effect('uses a provider Retry-After unchanged', () =>
+		Effect.gen(function* () {
+			const delay = yield* firstEventRetryDelayMs(
+				{ firstEventRetryBaseDelayMs: 1000, firstEventRetryMaxDelayMs: 10_000 },
+				0,
+				AiError.make({
+					module: 'test',
+					method: 'streamText',
+					reason: new AiError.RateLimitError({ retryAfter: Duration.seconds(16) }),
+				}),
+			)
+
+			expect(delay).toBe(16_000)
 		}),
 	)
 })


### PR DESCRIPTION
## Summary
- Retry retryable Codex provider failures only before any response part is emitted, so a fresh request cannot duplicate output or tool work.
- Honor an OpenAI `Retry-After` value for 429 responses instead of immediately exhausting retries, while retaining bounded fallback backoff.
- Cover acquisition and stream retry timing with deterministic TestClock tests, including the partial-output no-retry boundary.

## Verification
- `bun run --cwd packages/fold-codex typecheck`
- `bun --bun --cwd packages/fold-codex vitest run test/Hardening.vi.test.ts test/CodexModel.vi.test.ts`
- `bun --bun oxfmt --check packages/fold-codex/src/CodexModel.ts packages/fold-codex/src/Hardening.ts packages/fold-codex/test/CodexModel.vi.test.ts packages/fold-codex/test/Hardening.vi.test.ts`
- `git diff --check`