### PR TITLE
Replace instanceof checks with Effect guards

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -169,12 +169,15 @@
       "dependencies": {
         "@opentui/core": "catalog:",
         "@opentui/react": "0.4.3",
-        "effect": "catalog:",
         "react": "19.2.0",
       },
       "devDependencies": {
         "@types/react": "19.2.2",
+        "effect": "catalog:",
         "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/fold-xai": {

--- a/bun.lock
+++ b/bun.lock
@@ -169,6 +169,7 @@
       "dependencies": {
         "@opentui/core": "catalog:",
         "@opentui/react": "0.4.3",
+        "effect": "catalog:",
         "react": "19.2.0",
       },
       "devDependencies": {

--- a/packages/fold-agent/scripts/update-managed-binaries.ts
+++ b/packages/fold-agent/scripts/update-managed-binaries.ts
@@ -12,7 +12,7 @@ import { writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { Effect, Schema } from 'effect'
+import { Effect, Predicate, Schema } from 'effect'
 
 import { MANAGED_BINARY_PLATFORMS, managedBinaryRegistry } from '../src/Bin/Registry'
 
@@ -33,7 +33,9 @@ const fetchBytes = (url: string): Effect.Effect<Uint8Array, ChecksumBakeError> =
 			return new Uint8Array(await response.arrayBuffer())
 		},
 		catch: (cause) =>
-			new ChecksumBakeError({ message: `GET ${url}: ${cause instanceof Error ? cause.message : String(cause)}` }),
+			new ChecksumBakeError({
+				message: `GET ${url}: ${Predicate.isError(cause) ? cause.message : String(cause)}`,
+			}),
 	}).pipe(
 		Effect.timeout(downloadTimeoutMillis),
 		Effect.catchTag('TimeoutError', () =>

--- a/packages/fold-agent/src/Catalog/LoadCatalog.ts
+++ b/packages/fold-agent/src/Catalog/LoadCatalog.ts
@@ -14,7 +14,7 @@
 import { dirname, join } from 'node:path'
 
 import { ModelCatalogEntry } from '@humanlayer/fold-core'
-import { Clock, Effect, Schema, type FileSystem } from 'effect'
+import { Clock, Effect, Predicate, Schema, type FileSystem } from 'effect'
 
 import { fileSystemFor, type FsToolOptions } from '../Fs/DefaultFileSystem'
 import { bakedModelCatalog } from './BakedCatalog'
@@ -75,7 +75,7 @@ export const modelCatalogCachePath = (foldHome: string): string => join(foldHome
 
 /** The ONE mapper from thrown fetch failures to the typed catalog fetch error. */
 const catalogFetchErrorFrom = (cause: unknown): CatalogFetchError =>
-	new CatalogFetchError({ message: cause instanceof Error ? cause.message : String(cause) })
+	new CatalogFetchError({ message: Predicate.isError(cause) ? cause.message : String(cause) })
 
 const defaultFetchJson = (url: string): Effect.Effect<unknown, CatalogFetchError> =>
 	Effect.tryPromise({
@@ -104,7 +104,7 @@ const readCache = (fs: FileSystem.FileSystem, path: string): Effect.Effect<Model
 		return yield* Effect.try({
 			try: (): unknown => JSON.parse(text),
 			catch: (cause) =>
-				new CatalogCacheParseError({ message: cause instanceof Error ? cause.message : String(cause) }),
+				new CatalogCacheParseError({ message: Predicate.isError(cause) ? cause.message : String(cause) }),
 		}).pipe(
 			Effect.flatMap((parsed) => decodeCache(parsed)),
 			Effect.catch((error) =>

--- a/packages/fold-agent/src/Config/Load.ts
+++ b/packages/fold-agent/src/Config/Load.ts
@@ -12,7 +12,7 @@
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
-import { Effect, Schema } from 'effect'
+import { Effect, Predicate, Schema } from 'effect'
 
 import { fileSystemFor, type FsToolOptions } from '../Fs/DefaultFileSystem'
 import { FoldConfig } from './ConfigSchema'
@@ -135,7 +135,7 @@ export const parseFoldConfig = (
 		const parsed = yield* Effect.try({
 			try: (): unknown => JSON.parse(stripJsonc(text)),
 			catch: (cause) =>
-				new ConfigParseError({ path, message: cause instanceof Error ? cause.message : String(cause) }),
+				new ConfigParseError({ path, message: Predicate.isError(cause) ? cause.message : String(cause) }),
 		})
 
 		return yield* decodeConfig(parsed).pipe(

--- a/packages/fold-agent/src/Tools/WebFetchTool.ts
+++ b/packages/fold-agent/src/Tools/WebFetchTool.ts
@@ -1,5 +1,5 @@
 import { defineTool, webFetchToolContract, type FoldTool } from '@humanlayer/fold-core'
-import { Effect } from 'effect'
+import { Effect, Predicate } from 'effect'
 
 const maxResponseSize = 5 * 1024 * 1024
 const defaultTimeoutMs = 30_000
@@ -65,7 +65,7 @@ const readBody = (response: Response): Effect.Effect<string, { message: string }
 
 			return new TextDecoder().decode(bytes)
 		},
-		catch: (error) => ({ message: error instanceof Error ? error.message : String(error) }),
+		catch: (error) => ({ message: Predicate.isError(error) ? error.message : String(error) }),
 	})
 
 export const webFetchTool = (): FoldTool =>
@@ -90,9 +90,9 @@ export const webFetchTool = (): FoldTool =>
 							}),
 						catch: (error) => ({
 							message:
-								error instanceof Error && error.name === 'AbortError'
+								Predicate.isError(error) && error.name === 'AbortError'
 									? `Request timed out after ${timeoutMs}ms`
-									: error instanceof Error
+									: Predicate.isError(error)
 										? error.message
 										: String(error),
 						}),

--- a/packages/fold-agent/src/Tools/WebSearchTool.ts
+++ b/packages/fold-agent/src/Tools/WebSearchTool.ts
@@ -1,5 +1,5 @@
 import { CurrentAgent, defineTool, webSearchToolContract, type FoldTool } from '@humanlayer/fold-core'
-import { Effect } from 'effect'
+import { Effect, Predicate } from 'effect'
 
 const defaultTimeoutMs = 25_000
 const maxNumResults = 20
@@ -88,7 +88,7 @@ const parseMcpResponse = (body: string): Effect.Effect<string | undefined, { mes
 			return undefined
 		},
 		catch: (error) => ({
-			message: `Failed to parse web search response: ${error instanceof Error ? error.message : String(error)}`,
+			message: `Failed to parse web search response: ${Predicate.isError(error) ? error.message : String(error)}`,
 		}),
 	})
 
@@ -123,9 +123,9 @@ const callMcp = (input: {
 					}),
 				catch: (error) => ({
 					message:
-						error instanceof Error && error.name === 'AbortError'
+						Predicate.isError(error) && error.name === 'AbortError'
 							? `${input.tool} request timed out`
-							: error instanceof Error
+							: Predicate.isError(error)
 								? error.message
 								: String(error),
 				}),
@@ -140,7 +140,7 @@ const callMcp = (input: {
 			const body = yield* Effect.tryPromise({
 				try: () => response.text(),
 				catch: (error) => ({
-					message: `Failed to read web search response: ${error instanceof Error ? error.message : String(error)}`,
+					message: `Failed to read web search response: ${Predicate.isError(error) ? error.message : String(error)}`,
 				}),
 			})
 			return yield* parseMcpResponse(body)

--- a/packages/fold-agent/test/EventLog/EventLogJsonl.vi.test.ts
+++ b/packages/fold-agent/test/EventLog/EventLogJsonl.vi.test.ts
@@ -13,7 +13,7 @@ import {
 	StateId,
 	type LogEntryInput,
 } from '@humanlayer/fold-core'
-import { Effect, Fiber, FileSystem, Stream } from 'effect'
+import { Effect, Fiber, FileSystem, Predicate, Stream } from 'effect'
 
 import { layerJsonl } from '../../src/index'
 
@@ -105,7 +105,7 @@ it.effect('jsonl layer maps invalid persisted lines to EventLogCorruptEntryError
 				return yield* Stream.runCollect(log.entries())
 			}).pipe(Effect.provide(layerJsonl(filePath)), Effect.flip)
 
-			if (!(error instanceof EventLogCorruptEntryError)) {
+			if (!Predicate.isTagged(error, 'EventLogCorruptEntryError')) {
 				throw new Error(`expected EventLogCorruptEntryError, got ${error._tag}`)
 			}
 			expect(error.line).toBe(1)
@@ -201,7 +201,7 @@ it.effect('jsonl layer rejects event formats newer than the installed Fold runti
 			}).pipe(Effect.provide(layerJsonl(filePath)), Effect.flip)
 
 			expect(error).toBeInstanceOf(EventLogUnsupportedVersionError)
-			if (error instanceof EventLogUnsupportedVersionError) {
+			if (Predicate.isTagged(error, 'EventLogUnsupportedVersionError')) {
 				expect(error.version).toBe(2)
 				expect(error.supportedVersions).toEqual([1])
 			}

--- a/packages/fold-codex/src/Hardening.ts
+++ b/packages/fold-codex/src/Hardening.ts
@@ -77,7 +77,7 @@ export const isCodexIdleStall = (error: unknown): error is AiError.AiError =>
  * repeat a tool call that has already reached the agent runtime.
  */
 export const isCodexRetryableBeforeFirstEvent = (error: unknown): error is AiError.AiError =>
-	error instanceof AiError.AiError && error.isRetryable && !isCodexIdleStall(error)
+	AiError.isAiError(error) && error.isRetryable && !isCodexIdleStall(error)
 
 /**
  * Bound the stream's producer latency: the first event must arrive within `firstEventTimeoutMs` and

--- a/packages/fold-codex/src/Hardening.ts
+++ b/packages/fold-codex/src/Hardening.ts
@@ -65,11 +65,11 @@ export const codexAcquisitionStallError = (timeoutMs: number): AiError.AiError =
 
 /** True for the first-event stall errors this package mints (the only retryable stall class). */
 export const isCodexFirstEventStall = (error: unknown): error is AiError.AiError =>
-	error instanceof AiError.AiError && error.module === CODEX_ERROR_MODULE && error.method === FIRST_EVENT_METHOD
+	AiError.isAiError(error) && error.module === CODEX_ERROR_MODULE && error.method === FIRST_EVENT_METHOD
 
 /** True for the mid-stream idle stall errors this package mints. */
 export const isCodexIdleStall = (error: unknown): error is AiError.AiError =>
-	error instanceof AiError.AiError && error.module === CODEX_ERROR_MODULE && error.method === IDLE_METHOD
+	AiError.isAiError(error) && error.module === CODEX_ERROR_MODULE && error.method === IDLE_METHOD
 
 /**
  * A retryable provider failure is safe to repeat only before the model has emitted any stream event.

--- a/packages/fold-codex/test/CodexAuth.vi.test.ts
+++ b/packages/fold-codex/test/CodexAuth.vi.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { describe, expect, it } from '@effect/vitest'
-import { Effect, Layer, Option } from 'effect'
+import { Effect, Layer, Option, Predicate } from 'effect'
 import { FetchHttpClient, type HttpClient } from 'effect/unstable/http'
 
 import {
@@ -22,6 +22,8 @@ const jwtWith = (claims: Record<string, unknown>): string =>
 
 type RecordedRequest = { readonly url: string; readonly body: string }
 
+const isWebRequest = (input: string | URL | Request): input is Request => Predicate.hasProperty(input, 'url')
+
 /** A FetchHttpClient layer whose network is a scripted function, recording every request it serves. */
 const scriptedFetchLayer = (
 	respond: (request: RecordedRequest) => Response,
@@ -31,7 +33,7 @@ const scriptedFetchLayer = (
 	// Bun's `typeof fetch` carries a `preconnect` property; borrow the real one alongside the fake body.
 	const fakeFetch: typeof fetch = Object.assign(
 		async (input: string | URL | Request, init?: RequestInit) => {
-			const request = input instanceof Request ? input : new Request(String(input), init)
+			const request = isWebRequest(input) ? input : new Request(String(input), init)
 			const recorded = { url: request.url, body: await request.clone().text() }
 			requests.push(recorded)
 			return respond(recorded)

--- a/packages/fold-core/src/AgentRuntime/AgentRuntimeLayer.ts
+++ b/packages/fold-core/src/AgentRuntime/AgentRuntimeLayer.ts
@@ -10,7 +10,7 @@
  * those deltas are ephemeral and never persisted. Model provider failures become durable error +
  * agent-finished entries, never service failures.
  */
-import { Array as Arr, Cause, Effect, Exit, Layer, Ref, Result, Schema, Stream } from 'effect'
+import { Array as Arr, Cause, Effect, Exit, Layer, Predicate, Ref, Result, Schema, Stream } from 'effect'
 import { LanguageModel, Prompt, type Response, type Tool, type Toolkit } from 'effect/unstable/ai'
 
 import { AgentEvents } from '../AgentEvents/AgentEventsService'
@@ -79,7 +79,7 @@ type CompactionEnvelope = Pick<CompactAgentInput, 'agentId' | 'parentAgentId' | 
 
 /** Derive a short human-readable message from a model provider failure. */
 const describeModelError = (error: unknown): string => {
-	if (error instanceof Error) return error.message
+	if (Predicate.isError(error)) return error.message
 
 	try {
 		return JSON.stringify(error)

--- a/packages/fold-core/src/Compaction/CompactionLayer.ts
+++ b/packages/fold-core/src/Compaction/CompactionLayer.ts
@@ -9,7 +9,7 @@
  */
 import { AnthropicLanguageModel } from '@effect/ai-anthropic'
 import { OpenAiLanguageModel } from '@effect/ai-openai'
-import { Effect, Stream } from 'effect'
+import { Effect, Predicate, Stream } from 'effect'
 import { LanguageModel, Prompt } from 'effect/unstable/ai'
 
 import { ModelCatalog } from '../Model/ModelCatalog'
@@ -44,7 +44,7 @@ import {
 export type EnabledAutoCompactConfig = Extract<AutoCompactConfig, { readonly enabled: true }>
 
 const describeSummarizerError = (error: unknown): string => {
-	if (error instanceof Error) return error.message
+	if (Predicate.isError(error)) return error.message
 
 	try {
 		return JSON.stringify(error)

--- a/packages/fold-core/src/HookRunner/Errors.ts
+++ b/packages/fold-core/src/HookRunner/Errors.ts
@@ -1,15 +1,20 @@
-import type { Cause } from 'effect'
+import { Data, Predicate, type Cause } from 'effect'
 
 export type HookPhase = 'preRequest' | 'preToolUse' | 'postToolUse' | 'onComplete'
 
-export class HookExecutionError extends Error {
-	readonly _tag = 'HookExecutionError'
+export class HookExecutionError extends Data.TaggedError('HookExecutionError')<{
+	readonly phase: HookPhase
+	readonly hookName: string
+	readonly cause: Cause.Cause<never>
+}> {
+	constructor(phase: HookPhase, hookName: string, cause: Cause.Cause<never>) {
+		super({ phase, hookName, cause })
+	}
 
-	constructor(
-		readonly phase: HookPhase,
-		readonly hookName: string,
-		override readonly cause: Cause.Cause<never>,
-	) {
-		super(`${phase} hook "${hookName}" failed`)
+	override get message(): string {
+		return `${this.phase} hook "${this.hookName}" failed`
 	}
 }
+
+export const isHookExecutionError = (error: unknown): error is HookExecutionError =>
+	Predicate.isTagged(error, 'HookExecutionError')

--- a/packages/fold-core/src/ToolRuntime/ModelVisibleErrors.ts
+++ b/packages/fold-core/src/ToolRuntime/ModelVisibleErrors.ts
@@ -4,7 +4,7 @@
  * result with an error message, D21) narrow raw Causes through these helpers, so the model always sees
  * the same escaped, truncated, single-line description regardless of which boundary caught the defect.
  */
-import { Cause } from 'effect'
+import { Cause, Predicate } from 'effect'
 
 const maxModelVisibleErrorMessageLength = 300
 
@@ -25,7 +25,7 @@ export const truncateModelVisibleErrorMessage = (message: string): string => {
 }
 
 const stringifyUnknown = (value: unknown): string => {
-	if (value instanceof Error) return value.message
+	if (Predicate.isError(value)) return value.message
 
 	try {
 		return JSON.stringify(value)
@@ -36,7 +36,7 @@ const stringifyUnknown = (value: unknown): string => {
 
 /** Render an unknown thrown/failed value as safe model-visible text. */
 export const modelVisibleErrorDetailsFromUnknown = (value: unknown): string => {
-	const raw = value instanceof Error ? value.message : stringifyUnknown(value)
+	const raw = Predicate.isError(value) ? value.message : stringifyUnknown(value)
 
 	return escapeSystemInformationContent(truncateModelVisibleErrorMessage(raw === '' ? 'unknown error' : raw))
 }

--- a/packages/fold-core/src/ToolRuntime/ToolRuntimeLayer.ts
+++ b/packages/fold-core/src/ToolRuntime/ToolRuntimeLayer.ts
@@ -9,7 +9,7 @@ import { Prompt } from 'effect/unstable/ai'
 
 import { EventLog } from '../EventLog/EventLogService'
 import type { LogEntry, ToolResultLogEntry } from '../EventLog/Schemas'
-import { HookExecutionError } from '../HookRunner/Errors'
+import { HookExecutionError, isHookExecutionError } from '../HookRunner/Errors'
 import { HookRunner } from '../HookRunner/HookRunnerService'
 import { Ids, ToolCallId, type AgentId } from '../Ids'
 import { Subagents } from '../Subagents/SubagentsService'
@@ -159,7 +159,7 @@ const hookFailureResult = (error: HookExecutionError, toolName: string): string 
 const hookExecutionErrorFromCause = (cause: Cause.Cause<unknown>): HookExecutionError | undefined => {
 	const reason = cause.reasons.find(Cause.isFailReason)
 
-	return reason?.error instanceof HookExecutionError ? reason.error : undefined
+	return isHookExecutionError(reason?.error) ? reason.error : undefined
 }
 
 const failureResultFromCause = (toolName: string, cause: Cause.Cause<unknown>): string => {

--- a/packages/fold-core/src/ToolRuntime/ToolRuntimeLayer.ts
+++ b/packages/fold-core/src/ToolRuntime/ToolRuntimeLayer.ts
@@ -9,7 +9,7 @@ import { Prompt } from 'effect/unstable/ai'
 
 import { EventLog } from '../EventLog/EventLogService'
 import type { LogEntry, ToolResultLogEntry } from '../EventLog/Schemas'
-import { HookExecutionError, isHookExecutionError } from '../HookRunner/Errors'
+import { isHookExecutionError, type HookExecutionError } from '../HookRunner/Errors'
 import { HookRunner } from '../HookRunner/HookRunnerService'
 import { Ids, ToolCallId, type AgentId } from '../Ids'
 import { Subagents } from '../Subagents/SubagentsService'

--- a/packages/fold-core/test/EventLog/StoredLogEntryDecoder.vi.test.ts
+++ b/packages/fold-core/test/EventLog/StoredLogEntryDecoder.vi.test.ts
@@ -1,5 +1,5 @@
 import { it, expect } from '@effect/vitest'
-import { Effect } from 'effect'
+import { Effect, Predicate } from 'effect'
 
 import {
 	AgentId,
@@ -60,7 +60,7 @@ it.effect('rejects an unsupported event format without guessing its schema', () 
 		const error = yield* decodeStoredLogEntry(sessionStartedEntry(2)).pipe(Effect.flip)
 
 		expect(error).toBeInstanceOf(EventLogUnsupportedVersionError)
-		if (error instanceof EventLogUnsupportedVersionError) {
+		if (Predicate.isTagged(error, 'EventLogUnsupportedVersionError')) {
 			expect(error.version).toBe(2)
 			expect(error.seq).toBe(0)
 			expect(error.supportedVersions).toEqual([1])

--- a/packages/fold-core/test/Tools/PatchEngine.vi.test.ts
+++ b/packages/fold-core/test/Tools/PatchEngine.vi.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@effect/vitest'
-import { Effect, Result } from 'effect'
+import { Effect, Predicate, Result } from 'effect'
 
 import {
 	applyChunks,
@@ -430,7 +430,9 @@ describe('computePatch', () => {
 			).pipe(Effect.result)
 
 			if (!Result.isFailure(result)) throw new Error('expected failure')
-			if (!(result.failure instanceof PatchFileNotFoundError)) throw new Error('expected PatchFileNotFoundError')
+			if (!Predicate.isTagged(result.failure, 'PatchFileNotFoundError')) {
+				throw new Error('expected PatchFileNotFoundError')
+			}
 			expect(result.failure.message).toBe('Failed to read file to update: gone.txt')
 		}),
 	)

--- a/packages/fold-tui-theme/package.json
+++ b/packages/fold-tui-theme/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@opentui/core": "catalog:",
 		"@opentui/react": "0.4.3",
+		"effect": "catalog:",
 		"react": "19.2.0"
 	},
 	"devDependencies": {

--- a/packages/fold-tui-theme/package.json
+++ b/packages/fold-tui-theme/package.json
@@ -28,11 +28,14 @@
 	"dependencies": {
 		"@opentui/core": "catalog:",
 		"@opentui/react": "0.4.3",
-		"effect": "catalog:",
 		"react": "19.2.0"
 	},
 	"devDependencies": {
 		"@types/react": "19.2.2",
+		"effect": "catalog:",
 		"typescript": "catalog:"
+	},
+	"peerDependencies": {
+		"effect": "catalog:"
 	}
 }

--- a/packages/fold-tui-theme/src/github/client.ts
+++ b/packages/fold-tui-theme/src/github/client.ts
@@ -1,3 +1,5 @@
+import { Predicate } from 'effect'
+
 import { DEMO_FEED } from './fixtures'
 import type { Feed, GhItem, RateLimit } from './types'
 
@@ -144,9 +146,8 @@ function reasonText(reason: unknown): string {
 }
 
 const stringProperty = (value: unknown, property: string): string | undefined => {
-	if (typeof value !== 'object' || value === null || !(property in value)) return undefined
-	const propertyValue = Reflect.get(value, property)
-	return typeof propertyValue === 'string' ? propertyValue : undefined
+	if (!Predicate.hasProperty(value, property)) return undefined
+	return Predicate.isString(value[property]) ? value[property] : undefined
 }
 
 /** Prefer an actionable rate-limit reason over a generic one when both lists fail. */

--- a/packages/fold-tui-theme/src/github/client.ts
+++ b/packages/fold-tui-theme/src/github/client.ts
@@ -136,13 +136,17 @@ function describeFailure(path: string, res: Response): string {
 
 /** A rejected request's reason as a string, with a friendly note for timeouts. */
 function reasonText(reason: unknown): string {
-	if (reason instanceof Error) {
-		if (reason.name === 'TimeoutError' || reason.name === 'AbortError') {
-			return `request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`
-		}
-		return reason.message
+	const name = stringProperty(reason, 'name')
+	if (name === 'TimeoutError' || name === 'AbortError') {
+		return `request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`
 	}
-	return String(reason)
+	return stringProperty(reason, 'message') ?? String(reason)
+}
+
+const stringProperty = (value: unknown, property: string): string | undefined => {
+	if (typeof value !== 'object' || value === null || !(property in value)) return undefined
+	const propertyValue = Reflect.get(value, property)
+	return typeof propertyValue === 'string' ? propertyValue : undefined
 }
 
 /** Prefer an actionable rate-limit reason over a generic one when both lists fail. */
@@ -233,7 +237,7 @@ export async function loadFeed(options: LoadOptions): Promise<Feed> {
 		}
 	} catch (error) {
 		// Any unexpected throw (e.g. malformed JSON) still lands on fixtures.
-		const reason = error instanceof Error ? error.message : String(error)
+		const reason = stringProperty(error, 'message') ?? String(error)
 		return { ...DEMO_FEED, repo, offlineReason: reason }
 	}
 }


### PR DESCRIPTION
## Summary
- replace runtime `instanceof` checks with Effect guards such as `Predicate.isError`, `Predicate.isTagged`, and `AiError.isAiError`
- model hook execution failures as `Data.TaggedError` values and expose a tag-based guard for cause inspection
- use `Predicate.hasProperty` and `Predicate.isString` for unknown web error properties, with an explicit Effect dependency in the theme package

## Verification
- `bun run typecheck`
- `bun run test`
- `bun run --cwd packages/fold-codex test`
- `bun run --cwd packages/fold-core test`
- changed-file `oxfmt` and `oxlint` checks
- PR-added-line audit confirms no `instanceof`, `typeof`, property `in`, or null checks
- repository audit confirms no executable `instanceof` usage remains