### PR TITLE
fix(fold-xai): use Chat Completions for xAI tool calls

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -190,7 +190,7 @@
         "@humanlayer/fold-core": "workspace:*",
       },
       "devDependencies": {
-        "@effect/ai-openai": "catalog:",
+        "@effect/ai-openai-compat": "catalog:",
         "@effect/platform-node": "catalog:",
         "@effect/vitest": "catalog:",
         "@humanlayer/fold-vitest-config": "workspace:*",
@@ -199,7 +199,7 @@
         "vitest": "catalog:",
       },
       "peerDependencies": {
-        "@effect/ai-openai": "catalog:",
+        "@effect/ai-openai-compat": "catalog:",
         "@effect/platform-node": "catalog:",
         "effect": "catalog:",
       },

--- a/packages/fold-agent/src/Config/ConfigSchema.ts
+++ b/packages/fold-agent/src/Config/ConfigSchema.ts
@@ -54,7 +54,7 @@ export const RoleBinding = Schema.Struct({
 	model: Schema.optionalKey(
 		Schema.String.annotate({
 			description:
-				'Provider model id; defaults: codex/opencode → gpt-5.6-sol, xai → grok-4.5, anthropic → claude-opus-4-8; required for openai-compat',
+				'Provider model id; defaults: codex/opencode → gpt-5.6-sol, xai → grok-4.6, anthropic → claude-opus-4-8; required for openai-compat',
 		}),
 	),
 	/** Reasoning level for this role's requests. Defaults to `off` when omitted. */

--- a/packages/fold-agent/src/Config/ConfigSchemaJson.ts
+++ b/packages/fold-agent/src/Config/ConfigSchemaJson.ts
@@ -68,7 +68,7 @@ export const starterConfigJsonc = (): string =>
 
 	// Model roles bound to a provider (+ optional model). "smart" and "fast" are required;
 	// "orchestrator" is optional and falls back to "smart". Omitting "model" uses the provider
-	// defaults: codex/opencode → gpt-5.6-sol, xai → grok-4.5, anthropic → claude-opus-4-8.
+	// defaults: codex/opencode → gpt-5.6-sol, xai → grok-4.6, anthropic → claude-opus-4-8.
 	"roles": {
 		// Default primary model for new sessions.
 		"smart": { "provider": "codex", "model": "gpt-5.6-sol", "reasoning": "medium" },

--- a/packages/fold-agent/src/Config/FoldInfo.ts
+++ b/packages/fold-agent/src/Config/FoldInfo.ts
@@ -74,7 +74,7 @@ is optional and falls back to \`smart\`.
 | \`orchestrator\` | the RLM mode's primary agent |
 
 Each binding is \`{ "provider": <key>, "model"?: <id>, "reasoning"?: <level> }\`. Omitting \`model\`
-uses the provider kind's default: codex/opencode → \`gpt-5.6-sol\`, xai → \`grok-4.5\`, and
+uses the provider kind's default: codex/opencode → \`gpt-5.6-sol\`, xai → \`grok-4.6\`, and
 anthropic → \`claude-opus-4-8\`
 (openai-compat requires an explicit model). \`reasoning\` is one of \`off · minimal · low · medium ·
 high · xhigh · max\` and is validated against the model catalog - a level the model does not support

--- a/packages/fold-agent/test/Config/AgentModels.vi.test.ts
+++ b/packages/fold-agent/test/Config/AgentModels.vi.test.ts
@@ -68,7 +68,7 @@ it.effect('resolves OpenCode and xAI OAuth providers with their defaults and no 
 		const openCode = yield* models.resolve('smart')
 		const xai = yield* models.resolve('fast')
 		expect(openCode.activeModel).toMatchObject({ providerId: 'zen', modelId: 'gpt-5.6-sol', role: 'smart' })
-		expect(xai.activeModel).toMatchObject({ providerId: 'grok', modelId: 'grok-4.5', role: 'fast' })
+		expect(xai.activeModel).toMatchObject({ providerId: 'grok', modelId: 'grok-4.6', role: 'fast' })
 	}),
 )
 

--- a/packages/fold-agent/test/Config/ModelSelections.vi.test.ts
+++ b/packages/fold-agent/test/Config/ModelSelections.vi.test.ts
@@ -213,12 +213,12 @@ it.effect('provides OAuth defaults when the external catalog is unavailable', ()
 		})
 		expect(description.providers.find(({ name }) => name === 'grok')).toMatchObject({
 			credentialPresent: null,
-			models: ['grok-4.5'],
+			models: ['grok-4.6'],
 		})
 	}),
 )
 
-it.effect('only exposes Grok 4.5 for xAI providers', () =>
+it.effect('only exposes Grok 4.6 for xAI providers', () =>
 	Effect.gen(function* () {
 		const config = yield* parseFoldConfig(`{
 			"providers": { "grok": { "kind": "xai", "configuredModels": ["grok-3", "grok-4"] } },
@@ -228,6 +228,6 @@ it.effect('only exposes Grok 4.5 for xAI providers', () =>
 			}
 		}`)
 		const description = describeModelConfiguration(config, [catalogEntry('xai', 'grok-2')])
-		expect(description.providers[0]?.models).toEqual(['grok-4.5'])
+		expect(description.providers[0]?.models).toEqual(['grok-4.6'])
 	}),
 )

--- a/packages/fold-cli/src/tui/ProviderConfigState.ts
+++ b/packages/fold-cli/src/tui/ProviderConfigState.ts
@@ -32,7 +32,7 @@ export const emptyProviderForm = (): ProviderForm => ({
 const defaults = (kind: ProviderForm['kind']): Pick<ProviderForm, 'baseUrl' | 'model'> => {
 	if (kind === 'codex') return { baseUrl: 'https://chatgpt.com/backend-api/codex', model: 'gpt-5.6-sol' }
 	if (kind === 'opencode') return { baseUrl: 'https://opencode.ai/zen/v1', model: 'gpt-5.6-sol' }
-	if (kind === 'xai') return { baseUrl: 'https://api.x.ai/v1', model: 'grok-4.5' }
+	if (kind === 'xai') return { baseUrl: 'https://api.x.ai/v1', model: 'grok-4.6' }
 	if (kind === 'anthropic') return { baseUrl: 'https://api.anthropic.com', model: '' }
 	return { baseUrl: 'https://api.openai.com/v1', model: '' }
 }

--- a/packages/fold-cli/test/tui/ProviderConfigState.vi.test.ts
+++ b/packages/fold-cli/test/tui/ProviderConfigState.vi.test.ts
@@ -59,7 +59,7 @@ describe('provider config form state', () => {
 		const rows = providerManagementRows({ profiles: [], providers: [] })
 		expect(rows[3]).toMatchObject({
 			type: 'create',
-			form: { name: 'xai', kind: 'xai', baseUrl: 'https://api.x.ai/v1', model: 'grok-4.5' },
+			form: { name: 'xai', kind: 'xai', baseUrl: 'https://api.x.ai/v1', model: 'grok-4.6' },
 		})
 		expect(rows[4]).toMatchObject({
 			type: 'create',

--- a/packages/fold-xai/package.json
+++ b/packages/fold-xai/package.json
@@ -18,12 +18,12 @@
 		"@humanlayer/fold-core": "workspace:*"
 	},
 	"peerDependencies": {
-		"@effect/ai-openai": "catalog:",
+		"@effect/ai-openai-compat": "catalog:",
 		"@effect/platform-node": "catalog:",
 		"effect": "catalog:"
 	},
 	"devDependencies": {
-		"@effect/ai-openai": "catalog:",
+		"@effect/ai-openai-compat": "catalog:",
 		"@effect/platform-node": "catalog:",
 		"@effect/vitest": "catalog:",
 		"@humanlayer/fold-vitest-config": "workspace:*",

--- a/packages/fold-xai/src/XaiModel.ts
+++ b/packages/fold-xai/src/XaiModel.ts
@@ -1,5 +1,5 @@
 /** FoldModel factory for xAI's OpenAI-compatible inference API authenticated with OAuth. */
-import { OpenAiClient, OpenAiLanguageModel } from '@effect/ai-openai'
+import { OpenAiClient, OpenAiLanguageModel } from '@effect/ai-openai-compat'
 import { customModel, resolveOpenAiReasoning } from '@humanlayer/fold-core'
 import type { FoldModel, ReasoningLevel } from '@humanlayer/fold-core'
 import { Context, Effect, Layer } from 'effect'
@@ -11,7 +11,7 @@ import type { XaiAuthStore } from './AuthStore'
 import { makeXaiAuth, withXaiAuth } from './XaiAuth'
 
 export const XAI_API_URL = 'https://api.x.ai/v1'
-export const DEFAULT_XAI_MODEL_ID = 'grok-4.5'
+export const DEFAULT_XAI_MODEL_ID = 'grok-4.6'
 
 export type XaiModelOptions = {
 	readonly model?: string


### PR DESCRIPTION
## Summary
- Switch `fold-xai` from `@effect/ai-openai` (Responses API) to `@effect/ai-openai-compat` (Chat Completions API)
- xAI's `/v1/responses` endpoint has incomplete streaming support for tool calls — the stream hangs when Grok tries to call tools, leaving the session stuck with no assistant response
- `fold-opencode` already handles this by routing grok models through Chat Completions; this applies the same fix to the direct xAI OAuth provider
- Bumps default model from `grok-4.5` to `grok-4.6` (released Aug 12)

## Test plan
- [x] `bun vitest run` in `packages/fold-xai` — 3/3 tests pass
- [x] `bun --bun run typecheck --filter @humanlayer/fold-xai` — clean
- [ ] Manual: start a fold session with xAI provider and verify tool calls (read/edit/bash) complete instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)