### PR TITLE
feat: xAI model list + reasoning picker in TUI

### DIFF
--- a/packages/fold-agent/src/Config/ModelSelections.ts
+++ b/packages/fold-agent/src/Config/ModelSelections.ts
@@ -77,20 +77,17 @@ export const describeModelConfiguration = (
 		const defaultModels = Match.value(provider.kind).pipe(
 			Match.when('codex', () => [DEFAULT_OPENCODE_MODEL_ID]),
 			Match.when('opencode', () => [DEFAULT_OPENCODE_MODEL_ID, GROK_BUILD_MODEL_ID]),
-			Match.when('xai', () => [DEFAULT_XAI_MODEL_ID]),
+			Match.when('xai', () => ['grok-4.5', DEFAULT_XAI_MODEL_ID]),
 			Match.orElse((): ReadonlyArray<string> => []),
 		)
-		const models =
-			provider.kind === 'xai'
-				? [DEFAULT_XAI_MODEL_ID]
-				: [
-						...new Set([
-							...defaultModels,
-							...(provider.configuredModels ?? []),
-							...configured,
-							...catalogModels,
-						]),
-					].sort()
+		const models = [
+			...new Set([
+				...defaultModels,
+				...(provider.configuredModels ?? []),
+				...configured,
+				...catalogModels,
+			]),
+		].sort()
 		return {
 			name,
 			kind: provider.kind,

--- a/packages/fold-agent/src/Config/ModelSelections.ts
+++ b/packages/fold-agent/src/Config/ModelSelections.ts
@@ -81,12 +81,7 @@ export const describeModelConfiguration = (
 			Match.orElse((): ReadonlyArray<string> => []),
 		)
 		const models = [
-			...new Set([
-				...defaultModels,
-				...(provider.configuredModels ?? []),
-				...configured,
-				...catalogModels,
-			]),
+			...new Set([...defaultModels, ...(provider.configuredModels ?? []), ...configured, ...catalogModels]),
 		].sort()
 		return {
 			name,

--- a/packages/fold-agent/test/Config/ModelSelections.vi.test.ts
+++ b/packages/fold-agent/test/Config/ModelSelections.vi.test.ts
@@ -213,12 +213,12 @@ it.effect('provides OAuth defaults when the external catalog is unavailable', ()
 		})
 		expect(description.providers.find(({ name }) => name === 'grok')).toMatchObject({
 			credentialPresent: null,
-			models: ['grok-4.6'],
+			models: ['grok-4.5', 'grok-4.6'],
 		})
 	}),
 )
 
-it.effect('only exposes Grok 4.6 for xAI providers', () =>
+it.effect('merges configured, role-bound, and catalog models for xAI providers', () =>
 	Effect.gen(function* () {
 		const config = yield* parseFoldConfig(`{
 			"providers": { "grok": { "kind": "xai", "configuredModels": ["grok-3", "grok-4"] } },
@@ -228,6 +228,6 @@ it.effect('only exposes Grok 4.6 for xAI providers', () =>
 			}
 		}`)
 		const description = describeModelConfiguration(config, [catalogEntry('xai', 'grok-2')])
-		expect(description.providers[0]?.models).toEqual(['grok-4.6'])
+		expect(description.providers[0]?.models).toEqual(['grok-2', 'grok-3', 'grok-4', 'grok-4.5', 'grok-4.6'])
 	}),
 )

--- a/packages/fold-cli/src/tui/HostedTuiSession.ts
+++ b/packages/fold-cli/src/tui/HostedTuiSession.ts
@@ -183,7 +183,13 @@ export const makeHostedTuiSession = (
 					...(options.rpi === true ? { rpi: true } : {}),
 					...(selection._tag === 'profile'
 						? { profile: selection.profile }
-						: { modelSelection: { provider: selection.provider, model: selection.model } }),
+						: {
+								modelSelection: {
+									provider: selection.provider,
+									model: selection.model,
+									...(selection.reasoning === undefined ? {} : { reasoning: selection.reasoning }),
+								},
+							}),
 					reason: `TUI switch to ${selection.mode ?? mode()} mode`,
 				}).pipe(
 					Effect.tap(() =>

--- a/packages/fold-cli/src/tui/LaunchRequests.ts
+++ b/packages/fold-cli/src/tui/LaunchRequests.ts
@@ -12,7 +12,14 @@ export const requestToLaunchOptions = (options: TuiOptions, request: NewSessionR
 			? request.profile === 'default'
 				? {}
 				: { profile: request.profile }
-			: { modelSelection: { provider: request.provider, model: request.model }, mode: request.mode }),
+			: {
+				modelSelection: {
+					provider: request.provider,
+					model: request.model,
+					...(request.reasoning === undefined ? {} : { reasoning: request.reasoning }),
+				},
+				mode: request.mode,
+			}),
 	}
 }
 

--- a/packages/fold-cli/src/tui/LaunchRequests.ts
+++ b/packages/fold-cli/src/tui/LaunchRequests.ts
@@ -13,13 +13,13 @@ export const requestToLaunchOptions = (options: TuiOptions, request: NewSessionR
 				? {}
 				: { profile: request.profile }
 			: {
-				modelSelection: {
-					provider: request.provider,
-					model: request.model,
-					...(request.reasoning === undefined ? {} : { reasoning: request.reasoning }),
-				},
-				mode: request.mode,
-			}),
+					modelSelection: {
+						provider: request.provider,
+						model: request.model,
+						...(request.reasoning === undefined ? {} : { reasoning: request.reasoning }),
+					},
+					mode: request.mode,
+				}),
 	}
 }
 

--- a/packages/fold-cli/src/tui/ModelSelectionModal.tsx
+++ b/packages/fold-cli/src/tui/ModelSelectionModal.tsx
@@ -28,6 +28,8 @@ const heading = (state: ModelPickerState): string => {
 			return 'Provider'
 		case 'model':
 			return `Model · ${state.provider}`
+		case 'reasoning':
+			return 'Thinking'
 		case 'mode':
 			return 'Mode'
 	}

--- a/packages/fold-cli/src/tui/ModelSelectionState.ts
+++ b/packages/fold-cli/src/tui/ModelSelectionState.ts
@@ -41,8 +41,7 @@ const REASONING_LEVELS: ReadonlyArray<{ id: ReasoningLevel; label: string; detai
 	{ id: 'max', label: 'Max', detail: 'Maximum reasoning depth' },
 ]
 
-const toReasoningLevel = (choice: string): ReasoningLevel =>
-	REASONING_LEVELS.find((l) => l.id === choice)?.id ?? 'off'
+const toReasoningLevel = (choice: string): ReasoningLevel => REASONING_LEVELS.find((l) => l.id === choice)?.id ?? 'off'
 
 export const initialModelPickerState = (): ModelPickerState => ({ _tag: 'kind' })
 export const modelPickerChoices = (

--- a/packages/fold-cli/src/tui/ModelSelectionState.ts
+++ b/packages/fold-cli/src/tui/ModelSelectionState.ts
@@ -1,9 +1,16 @@
 import type { ConfiguredModelSelection, ModelConfiguration, ProfileModeName } from '@humanlayer/fold-agent'
+import type { ReasoningLevel } from '@humanlayer/fold-core'
 
 export type ModelSelectionContext = 'active' | 'new-session'
 export type ModelSelectionRequest =
 	| { readonly _tag: 'profile'; readonly profile: string; readonly mode?: ProfileModeName }
-	| { readonly _tag: 'direct'; readonly provider: string; readonly model: string; readonly mode?: ProfileModeName }
+	| {
+			readonly _tag: 'direct'
+			readonly provider: string
+			readonly model: string
+			readonly reasoning?: ReasoningLevel
+			readonly mode?: ProfileModeName
+	  }
 type StagedModelSelection =
 	| { readonly _tag: 'profile'; readonly profile: string }
 	| { readonly _tag: 'direct'; readonly provider: string; readonly model: string }
@@ -12,11 +19,27 @@ export type ModelPickerState =
 	| { readonly _tag: 'profile' }
 	| { readonly _tag: 'provider' }
 	| { readonly _tag: 'model'; readonly provider: string }
-	| { readonly _tag: 'mode'; readonly selection: StagedModelSelection }
+	| { readonly _tag: 'reasoning'; readonly selection: StagedModelSelection }
+	| { readonly _tag: 'mode'; readonly selection: StagedModelSelection; readonly reasoning?: ReasoningLevel }
 export type ModelPickerChoice = { readonly id: string; readonly label: string; readonly detail: string }
 
 export const configuredSelection = (request: ModelSelectionRequest): ConfiguredModelSelection =>
-	request._tag === 'profile' ? request : { _tag: 'direct', provider: request.provider, model: request.model }
+	request._tag === 'profile'
+		? request
+		: {
+				_tag: 'direct',
+				provider: request.provider,
+				model: request.model,
+				...(request.reasoning === undefined ? {} : { reasoning: request.reasoning }),
+			}
+
+const REASONING_LEVELS: ReadonlyArray<{ id: ReasoningLevel; label: string; detail: string }> = [
+	{ id: 'off', label: 'Off', detail: 'No extended thinking' },
+	{ id: 'low', label: 'Low', detail: 'Minimal reasoning' },
+	{ id: 'medium', label: 'Medium', detail: 'Moderate reasoning' },
+	{ id: 'high', label: 'High', detail: 'Thorough reasoning' },
+	{ id: 'max', label: 'Max', detail: 'Maximum reasoning depth' },
+]
 
 export const initialModelPickerState = (): ModelPickerState => ({ _tag: 'kind' })
 export const modelPickerChoices = (
@@ -59,6 +82,8 @@ export const modelPickerChoices = (
 					label: model,
 					detail: state.provider,
 				}))
+		case 'reasoning':
+			return REASONING_LEVELS
 		case 'mode':
 			return [
 				{ id: 'default', label: 'Default', detail: 'Smart root with standard tools' },
@@ -81,12 +106,21 @@ export const advanceModelPicker = (
 		case 'provider':
 			return { _tag: 'model', provider: choice }
 		case 'model':
-			return { _tag: 'mode', selection: { _tag: 'direct', provider: state.provider, model: choice } }
-		case 'mode':
+			return { _tag: 'reasoning', selection: { _tag: 'direct', provider: state.provider, model: choice } }
+		case 'reasoning':
 			return {
-				...state.selection,
-				mode: choice === 'rlm' ? 'rlm' : 'default',
+				_tag: 'mode',
+				selection: state.selection,
+				...(choice === 'off' ? {} : { reasoning: choice as ReasoningLevel }),
 			}
+		case 'mode':
+			return state.selection._tag === 'profile'
+				? { ...state.selection, mode: choice === 'rlm' ? 'rlm' : 'default' }
+				: {
+						...state.selection,
+						...(state.reasoning === undefined ? {} : { reasoning: state.reasoning }),
+						mode: choice === 'rlm' ? 'rlm' : 'default',
+					}
 	}
 }
 export const retreatModelPicker = (state: ModelPickerState): ModelPickerState | null => {
@@ -98,9 +132,11 @@ export const retreatModelPicker = (state: ModelPickerState): ModelPickerState | 
 			return { _tag: 'kind' }
 		case 'model':
 			return { _tag: 'provider' }
-		case 'mode':
+		case 'reasoning':
 			return state.selection._tag === 'profile'
 				? { _tag: 'profile' }
 				: { _tag: 'model', provider: state.selection.provider }
+		case 'mode':
+			return { _tag: 'reasoning', selection: state.selection }
 	}
 }

--- a/packages/fold-cli/src/tui/ModelSelectionState.ts
+++ b/packages/fold-cli/src/tui/ModelSelectionState.ts
@@ -41,6 +41,9 @@ const REASONING_LEVELS: ReadonlyArray<{ id: ReasoningLevel; label: string; detai
 	{ id: 'max', label: 'Max', detail: 'Maximum reasoning depth' },
 ]
 
+const toReasoningLevel = (choice: string): ReasoningLevel =>
+	REASONING_LEVELS.find((l) => l.id === choice)?.id ?? 'off'
+
 export const initialModelPickerState = (): ModelPickerState => ({ _tag: 'kind' })
 export const modelPickerChoices = (
 	configuration: ModelConfiguration,
@@ -111,7 +114,7 @@ export const advanceModelPicker = (
 			return {
 				_tag: 'mode',
 				selection: state.selection,
-				...(choice === 'off' ? {} : { reasoning: choice as ReasoningLevel }),
+				...(choice === 'off' ? {} : { reasoning: toReasoningLevel(choice) }),
 			}
 		case 'mode':
 			return state.selection._tag === 'profile'

--- a/packages/fold-cli/src/tui/NewSessionModal.tsx
+++ b/packages/fold-cli/src/tui/NewSessionModal.tsx
@@ -4,6 +4,7 @@ import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, normalize, resolve } from 'node:path'
 
 import type { ModelConfiguration, ProfileModeName } from '@humanlayer/fold-agent'
+import type { ReasoningLevel } from '@humanlayer/fold-core'
 import { TextAttributes, type KeyEvent, type TextareaRenderable } from '@opentui/core'
 import { registerManagedTextareaLayer } from '@opentui/keymap/addons/opentui'
 import { createDefaultOpenTuiKeymap } from '@opentui/keymap/opentui'
@@ -16,7 +17,13 @@ import { prepareTuiKeyboard } from './TuiKeymap'
 
 export type NewSessionRequest = { readonly cwd: string } & (
 	| { readonly _tag: 'profile'; readonly profile: string }
-	| { readonly _tag: 'direct'; readonly provider: string; readonly model: string; readonly mode: ProfileModeName }
+	| {
+			readonly _tag: 'direct'
+			readonly provider: string
+			readonly model: string
+			readonly reasoning?: ReasoningLevel
+			readonly mode: ProfileModeName
+	  }
 )
 
 const expandHome = (value: string): string =>
@@ -192,6 +199,7 @@ export const NewSessionModal = (props: {
 								_tag: 'direct',
 								provider: selection.provider,
 								model: selection.model,
+								...(selection.reasoning === undefined ? {} : { reasoning: selection.reasoning }),
 								mode: selection.mode,
 								cwd: cwd(),
 							})

--- a/packages/fold-cli/test/tui/ModelSelection.vi.test.ts
+++ b/packages/fold-cli/test/tui/ModelSelection.vi.test.ts
@@ -127,30 +127,52 @@ describe('model picker state machine', () => {
 		})
 	})
 
-	it('stages direct model then mode and supports stepwise escape', () => {
+	it('stages direct model then reasoning then mode and supports stepwise escape', () => {
 		const provider = requirePickerState(advanceModelPicker(initialModelPickerState(), 'direct', 'new-session'))
 		const model = requirePickerState(advanceModelPicker(provider, 'claude-alias', 'new-session'))
-		const mode = requirePickerState(advanceModelPicker(model, 'two', 'new-session'))
+		const reasoning = requirePickerState(advanceModelPicker(model, 'two', 'new-session'))
 
+		expect(reasoning).toEqual({
+			_tag: 'reasoning',
+			selection: { _tag: 'direct', provider: 'claude-alias', model: 'two' },
+		})
+
+		const mode = requirePickerState(advanceModelPicker(reasoning, 'high', 'new-session'))
 		expect(mode).toEqual({
 			_tag: 'mode',
 			selection: { _tag: 'direct', provider: 'claude-alias', model: 'two' },
+			reasoning: 'high',
 		})
 		expect(advanceModelPicker(mode, 'rlm', 'new-session')).toEqual({
 			_tag: 'direct',
 			provider: 'claude-alias',
 			model: 'two',
+			reasoning: 'high',
 			mode: 'rlm',
 		})
-		expect(retreatModelPicker(mode)).toEqual({ _tag: 'model', provider: 'claude-alias' })
+
+		expect(retreatModelPicker(mode)).toEqual({
+			_tag: 'reasoning',
+			selection: { _tag: 'direct', provider: 'claude-alias', model: 'two' },
+		})
+		expect(retreatModelPicker(reasoning)).toEqual({ _tag: 'model', provider: 'claude-alias' })
 		expect(retreatModelPicker({ _tag: 'provider' })).toEqual({ _tag: 'kind' })
 		expect(retreatModelPicker({ _tag: 'kind' })).toBeNull()
 	})
 
-	it('asks for mode when switching an active direct model', () => {
+	it('omits reasoning from selection when set to off', () => {
+		const reasoning = requirePickerState(
+			advanceModelPicker({ _tag: 'model', provider: 'claude-alias' }, 'one', 'new-session'),
+		)
+		const mode = requirePickerState(advanceModelPicker(reasoning, 'off', 'new-session'))
+		expect(mode).not.toHaveProperty('reasoning')
+		expect(advanceModelPicker(mode, 'default', 'new-session')).not.toHaveProperty('reasoning')
+	})
+
+	it('asks for reasoning when switching an active direct model', () => {
 		const model = { _tag: 'model' as const, provider: 'claude-alias' }
 		expect(advanceModelPicker(model, 'one', 'active')).toEqual({
-			_tag: 'mode',
+			_tag: 'reasoning',
 			selection: { _tag: 'direct', provider: 'claude-alias', model: 'one' },
 		})
 	})


### PR DESCRIPTION
## Summary
- Remove the hardcoded xAI-only-grok-4.6 model list so xAI uses the same merge logic (defaults + configuredModels + role bindings + catalog) as every other provider
- Add grok-4.5 as a default model alongside grok-4.6
- Add a "Thinking" step to the TUI model picker between model and mode selection with Off/Low/Medium/High/Max choices
- Thread reasoning through the full selection pipeline: ModelSelectionState → ModelSelectionModal → NewSessionModal → LaunchRequests → HostedTuiSession → switchSessionMode

## Test plan
- [x] `ModelSelections.vi.test.ts` updated: xAI now merges all model sources instead of hardcoding
- [x] `ModelSelection.vi.test.ts` updated: picker flow is model → reasoning → mode, with `off` omitting reasoning from final selection
- [x] Typecheck passes clean on fold-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)