### PR TITLE
Configure fork history and prompt cache affinity

### DIFF
--- a/packages/fold-core/src/AgentRuntime/AgentRuntimeLayer.ts
+++ b/packages/fold-core/src/AgentRuntime/AgentRuntimeLayer.ts
@@ -359,6 +359,7 @@ export const liveAgentRuntimeLayer: Layer.Layer<
 					modelRequestSettings.wrap({
 						model: runtimeState.activeModel,
 						reasoningLevel: runtimeState.reasoningLevel,
+						promptCacheKey: runtimeState.promptCacheKey,
 					}),
 					Effect.result,
 				)
@@ -544,6 +545,7 @@ export const liveAgentRuntimeLayer: Layer.Layer<
 					toolCallId: input.toolCallId,
 					mode: input.mode,
 					model: input.model,
+					...(input.promptCacheKey == null ? {} : { promptCacheKey: input.promptCacheKey }),
 					tools: resolvedToolset.names,
 					skill: input.skill,
 					fork: input.fork,

--- a/packages/fold-core/src/AgentRuntime/AgentRuntimeService.ts
+++ b/packages/fold-core/src/AgentRuntime/AgentRuntimeService.ts
@@ -32,6 +32,7 @@ export type StartAgentInput = {
 	/** Registry type name the agent was dispatched as (D21); null for the root agent and forks. */
 	readonly agentType: string | null
 	readonly model: ActiveModel
+	readonly promptCacheKey?: string | null
 	/** One leading system block, an ordered set of blocks (one system message each), or null for none. */
 	readonly systemPrompt: string | ReadonlyArray<string> | null
 }

--- a/packages/fold-core/src/Api/AgentDefinition.ts
+++ b/packages/fold-core/src/Api/AgentDefinition.ts
@@ -17,6 +17,8 @@ export type AgentDefinition = {
 	readonly name?: string
 	/** The model the agent starts on. Sessions can switch later with `FoldSession.switchModel`. */
 	readonly model: FoldModel
+	/** Stable provider cache-affinity key. Forked children derive and persist their own key from this one. */
+	readonly promptCacheKey?: string
 	/** The agent's own leading system prompt: one block or an ordered set of blocks. */
 	readonly systemPrompt?: string | ReadonlyArray<string>
 	/**

--- a/packages/fold-core/src/Api/StartSession.ts
+++ b/packages/fold-core/src/Api/StartSession.ts
@@ -254,6 +254,7 @@ export type FoldSession = {
 /** The switchable slice of a session's configuration, tracked so omitted switch options carry forward. */
 type SessionAgentConfig = {
 	readonly model: FoldModel
+	readonly promptCacheKey: string | null
 	readonly systemPrompt: string | ReadonlyArray<string> | null
 	readonly tools: ReadonlyArray<FoldTool>
 }
@@ -402,6 +403,7 @@ const assembleSessionGraph = (options: {
 
 		const initialConfig: SessionAgentConfig = {
 			model: agent.model,
+			promptCacheKey: agent.promptCacheKey ?? null,
 			systemPrompt: agent.systemPrompt ?? null,
 			tools: rootTools,
 		}
@@ -487,6 +489,7 @@ const assembleSessionGraph = (options: {
 		const currentRootAgent: Effect.Effect<RootAgentSnapshot> = Ref.get(configRef).pipe(
 			Effect.map((config) => ({
 				model: config.model,
+				promptCacheKey: config.promptCacheKey,
 				tools: config.tools,
 				hooks: rootHooks,
 				systemPrompt: config.systemPrompt,
@@ -814,6 +817,7 @@ const makeSessionHandle = (graph: SessionGraph, identity: StartedSession): FoldS
 				const candidateProfiles = switchOptions?.profiles ?? currentProfiles
 				const next: SessionAgentConfig = {
 					model,
+					promptCacheKey: current.promptCacheKey,
 					systemPrompt: switchOptions?.systemPrompt ?? current.systemPrompt,
 					tools: switchOptions?.tools ?? current.tools,
 				}
@@ -915,6 +919,7 @@ export const startSession = (options: StartSessionOptions): Effect.Effect<FoldSe
 			.start({
 				cwd: options.cwd ?? null,
 				model: options.agent.model.activeModel,
+				...(options.agent.promptCacheKey === undefined ? {} : { promptCacheKey: options.agent.promptCacheKey }),
 				systemPrompt: graph.leadingPromptFor(config.systemPrompt, config.tools),
 				meta: {
 					...options.meta,

--- a/packages/fold-core/src/EventLog/Schemas.ts
+++ b/packages/fold-core/src/EventLog/Schemas.ts
@@ -209,6 +209,10 @@ export const AgentFork = Schema.Struct({
 	atSeq: LogSeq,
 	/** Host fork configuration. Absent on legacy and default toolset-inheriting forks. */
 	definitionId: Schema.optionalKey(ForkAgentDefinitionId),
+	/** Eligible caller history inherited by this fork. Absent on legacy forks and interpreted as all. */
+	history: Schema.optionalKey(
+		Schema.Union([Schema.Literals(['all', 'none']), Schema.Int.check(Schema.isGreaterThan(0))]),
+	),
 }).annotate({ identifier: 'AgentFork' })
 export type AgentFork = typeof AgentFork.Type
 
@@ -259,6 +263,7 @@ export const AgentStartedLogEntryInput = Schema.TaggedStruct('agent_started', {
 	toolCallId: Schema.NullOr(ToolCallId),
 	mode: AgentLaunchMode,
 	model: ActiveModel,
+	promptCacheKey: Schema.optionalKey(Schema.String),
 	tools: Schema.Array(Schema.String),
 	skill: Schema.NullOr(Schema.String),
 	fork: Schema.NullOr(AgentFork),
@@ -278,6 +283,7 @@ export const AgentStartedLogEntry = Schema.TaggedStruct('agent_started', {
 	toolCallId: Schema.NullOr(ToolCallId),
 	mode: AgentLaunchMode,
 	model: ActiveModel,
+	promptCacheKey: Schema.optionalKey(Schema.String),
 	tools: Schema.Array(Schema.String),
 	skill: Schema.NullOr(Schema.String),
 	fork: Schema.NullOr(AgentFork),

--- a/packages/fold-core/src/Model/ModelRequestSettings.ts
+++ b/packages/fold-core/src/Model/ModelRequestSettings.ts
@@ -108,6 +108,7 @@ export const anthropicEffortForLevel = (level: ReasoningLevel): 'low' | 'medium'
 export type WrapModelRequestInput = {
 	readonly model: ActiveModel | null
 	readonly reasoningLevel: ReasoningLevel | null
+	readonly promptCacheKey?: string | null
 }
 
 /**
@@ -136,7 +137,7 @@ const identity = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R>
  * pre-adaptive models) through the Anthropic provider's `Config`.
  */
 export const liveModelRequestSettingsLayer: Layer.Layer<ModelRequestSettings> = Layer.succeed(ModelRequestSettings, {
-	wrap: ({ model, reasoningLevel }) => {
+	wrap: ({ model, reasoningLevel, promptCacheKey = null }) => {
 		if (model === null) return identity
 
 		const level = reasoningLevel ?? model.requestedReasoningLevel
@@ -149,6 +150,7 @@ export const liveModelRequestSettingsLayer: Layer.Layer<ModelRequestSettings> = 
 				return (self) =>
 					OpenAiLanguageModel.withConfigOverride(self, {
 						model: model.modelId,
+						...(promptCacheKey === null ? {} : { prompt_cache_key: promptCacheKey }),
 						...(setting._tag === 'disabled' ? {} : { reasoning: { effort: setting.effort } }),
 					})
 			}
@@ -159,6 +161,7 @@ export const liveModelRequestSettingsLayer: Layer.Layer<ModelRequestSettings> = 
 				return (self) =>
 					OpenAiLanguageModel.withConfigOverride(self, {
 						model: model.modelId,
+						...(promptCacheKey === null ? {} : { prompt_cache_key: promptCacheKey }),
 						...(setting._tag === 'disabled'
 							? {}
 							: { reasoning: { effort: setting.effort, summary: setting.summary } }),

--- a/packages/fold-core/src/Projection/Projection.ts
+++ b/packages/fold-core/src/Projection/Projection.ts
@@ -28,6 +28,7 @@ export type AgentRuntimeProjection = AgentLifecycleProjection & {
 	readonly activeModel: ActiveModel | null
 	readonly activeTools: ReadonlyArray<string>
 	readonly reasoningLevel: ReasoningLevel | null
+	readonly promptCacheKey: string | null
 }
 
 /** Helper for projected records that keep the durable entry discriminant and selected payload fields. */
@@ -86,6 +87,60 @@ const findAgentFinished = (entries: ReadonlyArray<LogEntry>, agentId: AgentId): 
 
 const compareSeq = (left: LogEntry, right: LogEntry) => left.seq - right.seq
 
+const userMessageText = (entry: UserMessageLogEntry): string =>
+	typeof entry.message.content === 'string'
+		? entry.message.content
+		: entry.message.content.flatMap((part) => (part.type === 'text' ? [part.text] : [])).join('')
+
+const isInjectedSkillMessage = (entry: LogEntry): boolean => {
+	if (entry._tag !== 'user-message') return false
+	const content = userMessageText(entry).trim()
+	return /^<skill(?:\s|>)/.test(content) && content.endsWith('</skill>')
+}
+
+const isSettledAssistantText = (entry: LogEntry): boolean => {
+	if (entry._tag !== 'assistant-message') return false
+	if (typeof entry.message.content === 'string') return entry.message.content.trim().length > 0
+	return entry.message.content.length > 0 && entry.message.content.every((part) => part.type === 'text')
+}
+
+const eligibleForkHistory = (
+	entries: ReadonlyArray<LogEntry>,
+	history: 'all' | 'none' | number,
+): ReadonlyArray<LogEntry> => {
+	const leadingSystem = entries.filter((entry) => entry._tag === 'system-message' && entry.placement === 'leading')
+	if (history === 'none') return leadingSystem
+
+	let invokingTurnStart = entries.length
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index]
+		if (entry?._tag === 'user-message' && !isInjectedSkillMessage(entry)) {
+			invokingTurnStart = index
+			break
+		}
+	}
+
+	const eligible = entries
+		.slice(0, invokingTurnStart)
+		.filter(
+			(entry) =>
+				(entry._tag === 'system-message' && entry.placement === 'leading') ||
+				entry._tag === 'user-message' ||
+				isSettledAssistantText(entry),
+		)
+	if (history === 'all') return eligible
+
+	let userTurns = 0
+	for (let index = eligible.length - 1; index >= 0; index -= 1) {
+		const entry = eligible[index]
+		if (entry?._tag !== 'user-message' || isInjectedSkillMessage(entry)) continue
+		userTurns += 1
+		if (userTurns === history)
+			return [...leadingSystem, ...eligible.slice(index).filter((item) => item._tag !== 'system-message')]
+	}
+	return eligible
+}
+
 const entriesForAgentInternal = (
 	entries: ReadonlyArray<LogEntry>,
 	agentId: AgentId,
@@ -104,7 +159,9 @@ const entriesForAgentInternal = (
 		(entry) => entry.seq <= fork.atSeq,
 	)
 
-	return [...parentEntries, ...ownEntries].sort(compareSeq)
+	const inheritedEntries =
+		fork.history === undefined ? parentEntries : eligibleForkHistory(parentEntries, fork.history)
+	return [...inheritedEntries, ...ownEntries].sort(compareSeq)
 }
 
 /**
@@ -137,6 +194,7 @@ export const runtimeForAgent = (entries: ReadonlyArray<LogEntry>, agentId: Agent
 	let activeModel: ActiveModel | null = null
 	let activeTools: ReadonlyArray<string> = []
 	let reasoningLevel: ReasoningLevel | null = null
+	let promptCacheKey: string | null = null
 
 	for (const entry of visibleEntries) {
 		switch (entry._tag) {
@@ -144,6 +202,7 @@ export const runtimeForAgent = (entries: ReadonlyArray<LogEntry>, agentId: Agent
 				activeModel = entry.model
 				activeTools = entry.tools
 				reasoningLevel = entry.model.requestedReasoningLevel
+				promptCacheKey = entry.promptCacheKey ?? null
 				break
 			case 'model-change':
 				activeModel = entry.model
@@ -163,6 +222,7 @@ export const runtimeForAgent = (entries: ReadonlyArray<LogEntry>, agentId: Agent
 		activeModel,
 		activeTools,
 		reasoningLevel,
+		promptCacheKey,
 	}
 }
 

--- a/packages/fold-core/src/Session/SessionLayer.ts
+++ b/packages/fold-core/src/Session/SessionLayer.ts
@@ -78,6 +78,7 @@ export const liveSessionLayer: Layer.Layer<Session, never, EventLog | Ids | Agen
 					skill: null,
 					agentType: null,
 					model: input.model,
+					promptCacheKey: input.promptCacheKey ?? null,
 					systemPrompt: input.systemPrompt,
 				})
 

--- a/packages/fold-core/src/Session/SessionService.ts
+++ b/packages/fold-core/src/Session/SessionService.ts
@@ -16,6 +16,7 @@ export type StartSessionInput = {
 	/** Host working directory recorded on `session_started`; omit (or pass null) on hosts without a filesystem. */
 	readonly cwd?: string | null
 	readonly model: ActiveModel
+	readonly promptCacheKey?: string
 	/** One leading system block, an ordered set of blocks (one system message each), or null for none. */
 	readonly systemPrompt: string | ReadonlyArray<string> | null
 	readonly meta?: Readonly<Record<string, typeof Schema.Json.Type>>

--- a/packages/fold-core/src/Subagents/Schemas.ts
+++ b/packages/fold-core/src/Subagents/Schemas.ts
@@ -83,6 +83,9 @@ export const ForkSubagentInput = Schema.Struct({
 	prompt: Schema.String,
 	skill: Schema.NullOr(Schema.String),
 	forkAgentDefinitionId: Schema.NullOr(ForkAgentDefinitionId),
+	history: Schema.optionalKey(
+		Schema.Union([Schema.Literals(['all', 'none']), Schema.Int.check(Schema.isGreaterThan(0))]),
+	),
 }).annotate({ identifier: 'ForkSubagentInput' })
 export type ForkSubagentInput = typeof ForkSubagentInput.Type
 

--- a/packages/fold-core/src/Subagents/SubagentsLayer.ts
+++ b/packages/fold-core/src/Subagents/SubagentsLayer.ts
@@ -72,6 +72,7 @@ export type RealizedAgentTools = {
 /** The root agent's current configuration; model switches move it (read fresh per dispatch). */
 export type RootAgentSnapshot = {
 	readonly model: FoldModel
+	readonly promptCacheKey: string | null
 	/** The root's tools as configured (system-tool values included). */
 	readonly tools: ReadonlyArray<FoldTool>
 	readonly hooks: HookConfig
@@ -92,6 +93,7 @@ type OriginatingConfig = { readonly _tag: 'entry'; readonly entry: RegisteredAge
 
 type AgentConfigurationSnapshot = {
 	readonly model: FoldModel
+	readonly promptCacheKey: string | null
 	readonly tools: ReadonlyArray<FoldTool>
 	readonly hooks: HookConfig
 	readonly systemPrompt: string | ReadonlyArray<string> | null
@@ -109,6 +111,7 @@ type LaunchSubagentParams = {
 	readonly mode: AgentLaunchMode
 	readonly fork: AgentFork | null
 	readonly model: FoldModel
+	readonly promptCacheKey: string | null
 	readonly tools: ReadonlyArray<RealizedFoldTool>
 	readonly hooks: HookConfig
 	/** Leading blocks for fresh starts (entry blocks + tool-contributed blocks); null for forks/resumes. */
@@ -193,6 +196,16 @@ const lastAssistantTextForRun = (
 /** Structural model-binding comparison deciding whether a resume needs a D17 transition. */
 const activeModelsDiffer = (left: unknown, right: unknown): boolean => JSON.stringify(left) !== JSON.stringify(right)
 
+const CHILD_CACHE_SUFFIX_LENGTH = 28
+const MAX_PROMPT_CACHE_KEY_LENGTH = 64
+
+/** Derive a bounded, deterministic child cache-affinity key from its parent and durable id. */
+export const deriveChildPromptCacheKey = (parentKey: string, agentId: AgentId): Effect.Effect<string> => {
+	const suffix = `:${agentId.slice(-CHILD_CACHE_SUFFIX_LENGTH)}`
+	const parentLength = MAX_PROMPT_CACHE_KEY_LENGTH - suffix.length
+	return Effect.succeed(`${parentKey.slice(0, parentLength)}${suffix}`)
+}
+
 /**
  * Build the Subagents engine over the session's shared services. `startSession` constructs this once
  * per session (after the registry and tool contributions exist) and publishes it as the ambient
@@ -270,6 +283,7 @@ export const makeSubagents = (
 				: resolveModelBinding(origin.entry.model).pipe(
 						Effect.map((model) => ({
 							model,
+							promptCacheKey: null,
 							tools: origin.entry.tools,
 							hooks: origin.entry.hooks,
 							systemPrompt: origin.entry.systemPrompt,
@@ -287,8 +301,10 @@ export const makeSubagents = (
 
 				const snapshot = yield* agentSnapshotForOrigin(origin)
 				const started = findAgentStarted(entries, agentId)
-				const definitionId = started?.fork?.definitionId
-				if (definitionId === undefined) return snapshot
+				if (started === null) return snapshot
+				const withCacheKey = { ...snapshot, promptCacheKey: started.promptCacheKey ?? snapshot.promptCacheKey }
+				const definitionId = started.fork?.definitionId
+				if (definitionId === undefined) return withCacheKey
 
 				const definition = config.registry.resolveForkAgentDefinition(definitionId)
 				if (definition === null) {
@@ -297,7 +313,10 @@ export const makeSubagents = (
 					)
 				}
 
-				return { ...snapshot, tools: definition.tools }
+				return {
+					...withCacheKey,
+					tools: definition.tools,
+				}
 			})
 
 		/** Every ancestor of an agent (parent chain from agent_started rows), for the resume self-guard. */
@@ -451,6 +470,7 @@ export const makeSubagents = (
 							skill: params.skillParam,
 							agentType: params.agentTypeName,
 							model: params.model.activeModel,
+							promptCacheKey: params.promptCacheKey,
 							systemPrompt: params.systemPrompt,
 						})
 					} else if (params.launch.modelTransition !== null) {
@@ -688,14 +708,19 @@ export const makeSubagents = (
 					// subagent row exists (§2.3 step 6).
 					const entries = yield* collectEntries
 					const dispatcherSnapshot = yield* agentSnapshotForAgent(entries, dispatcher.agentId)
+					if (dispatcherSnapshot === null) {
+						return yield* Effect.die(
+							new Error(`dispatching agent ${dispatcher.agentId} has no resolvable configuration`),
+						)
+					}
 					const preloaded =
-						input.skill === null
-							? null
-							: dispatcherSnapshot === null
-								? yield* new SkillNotFoundError({ name: input.skill, availableSkills: [] })
-								: yield* preloadedSkillMessage(dispatcherSnapshot, input.skill)
+						input.skill === null ? null : yield* preloadedSkillMessage(dispatcherSnapshot, input.skill)
 
 					const subagentId = yield* ids.makeAgentId
+					const promptCacheKey =
+						dispatcherSnapshot.promptCacheKey === null
+							? null
+							: yield* deriveChildPromptCacheKey(dispatcherSnapshot.promptCacheKey, subagentId)
 					yield* interruptNote.set(interruptedSubagentNote(entry.name, subagentId, 0))
 
 					const realized = config.realizeAgentTools(entry.tools)
@@ -710,6 +735,7 @@ export const makeSubagents = (
 						fork: null,
 						// Role bindings resolve at dispatch time: a setProfile swap binds the NEXT dispatch.
 						model: yield* resolveModelBinding(entry.model),
+						promptCacheKey,
 						tools: realized.tools,
 						hooks: entry.hooks,
 						systemPrompt: leadingBlocksFor(entry.systemPrompt, realized),
@@ -758,6 +784,10 @@ export const makeSubagents = (
 				}
 
 				const subagentId = yield* ids.makeAgentId
+				const promptCacheKey =
+					dispatcherSnapshot.promptCacheKey === null
+						? null
+						: yield* deriveChildPromptCacheKey(dispatcherSnapshot.promptCacheKey, subagentId)
 				const agentLabel = `fork of ${shortAgentId(dispatcher.agentId)}`
 				yield* interruptNote.set(interruptedSubagentNote(agentLabel, subagentId, 0))
 
@@ -772,8 +802,10 @@ export const makeSubagents = (
 						fromAgentId: dispatcher.agentId,
 						atSeq: lastEntry.seq,
 						...(input.forkAgentDefinitionId === null ? {} : { definitionId: input.forkAgentDefinitionId }),
+						...(input.history === undefined ? {} : { history: input.history }),
 					},
 					model: dispatcherSnapshot.model,
+					promptCacheKey,
 					tools: realized.tools,
 					hooks: dispatcherSnapshot.hooks,
 					// Forks append no leading system message: the fold carries the caller's blocks (D21).
@@ -850,6 +882,7 @@ export const makeSubagents = (
 					mode: started.mode,
 					fork: started.fork,
 					model: snapshot.model,
+					promptCacheKey: snapshot.promptCacheKey,
 					tools: realized.tools,
 					hooks: snapshot.hooks,
 					systemPrompt: null,

--- a/packages/fold-core/test/Model/ModelRequestSettings.vi.test.ts
+++ b/packages/fold-core/test/Model/ModelRequestSettings.vi.test.ts
@@ -125,6 +125,18 @@ it.effect('binds the projected model id and stored reasoning when the level matc
 	}),
 )
 
+it.effect('binds an agent-specific prompt cache key on OpenAI requests', () =>
+	Effect.gen(function* () {
+		const configs = yield* observedConfigs({
+			model: codexModel,
+			reasoningLevel: 'high',
+			promptCacheKey: 'session-child-affinity',
+		})
+
+		expect(Reflect.get(configs.openai ?? {}, 'prompt_cache_key')).toBe('session-child-affinity')
+	}),
+)
+
 it.effect('re-derives the setting from the projected level after a thinking-change', () =>
 	Effect.gen(function* () {
 		const configs = yield* observedConfigs({ model: openAiMediumModel, reasoningLevel: 'high' })

--- a/packages/fold-core/test/Projection/Projection.vi.test.ts
+++ b/packages/fold-core/test/Projection/Projection.vi.test.ts
@@ -53,6 +53,9 @@ const assistantWithToolCalls = (toolCallIds: ReadonlyArray<ToolCallId>) =>
 		}),
 	)
 
+const assistantText = (text: string) =>
+	Schema.encodeUnknownSync(Prompt.AssistantMessage)(Prompt.assistantMessage({ content: [Prompt.textPart({ text })] }))
+
 const toolMessage = (toolCallId: ToolCallId, index: number): ToolMessageEncoded =>
 	Schema.encodeUnknownSync(Prompt.ToolMessage)(
 		Prompt.toolMessage({
@@ -338,6 +341,76 @@ it.effect('projects forked agents through the parent fork sequence plus child en
 		expect(projected.map((message) => message._tag)).toEqual(['system-message', 'user-message', 'user-message'])
 		expect(projected[1]).toMatchObject({ _tag: 'user-message', message: { content: 'parent before fork' } })
 		expect(projected[2]).toMatchObject({ _tag: 'user-message', message: { content: 'child prompt' } })
+	}),
+)
+
+it.effect('configured fork history keeps recent completed turns and removes the invoking turn', () =>
+	Effect.gen(function* () {
+		const result = yield* Effect.gen(function* () {
+			const log = yield* EventLog
+			const rootAgentId = yield* appendRoot()
+			for (const [user, assistant] of [
+				['old user', 'old assistant'],
+				['recent user', 'recent assistant'],
+			] as const) {
+				yield* log.append({
+					_tag: 'user-message',
+					agentId: rootAgentId,
+					parentAgentId: null,
+					toolCallId: null,
+					messageId: yield* messageId,
+					message: userMessage(user),
+				})
+				yield* log.append({
+					_tag: 'assistant-message',
+					agentId: rootAgentId,
+					parentAgentId: null,
+					toolCallId: null,
+					messageId: yield* messageId,
+					message: assistantText(assistant),
+					finish: null,
+				})
+			}
+			yield* log.append({
+				_tag: 'user-message',
+				agentId: rootAgentId,
+				parentAgentId: null,
+				toolCallId: null,
+				messageId: yield* messageId,
+				message: userMessage('invoking user'),
+			})
+
+			const childAgentId = yield* agentId
+			const dispatchToolCallId = yield* toolCallId
+			yield* log.append({
+				_tag: 'agent_started',
+				agentId: childAgentId,
+				parentAgentId: rootAgentId,
+				toolCallId: dispatchToolCallId,
+				mode: 'fork',
+				model,
+				tools: [],
+				skill: null,
+				fork: { fromAgentId: rootAgentId, atSeq: lastSeq(yield* readEntries), history: 1 },
+				agentType: null,
+			})
+			yield* log.append({
+				_tag: 'user-message',
+				agentId: childAgentId,
+				parentAgentId: rootAgentId,
+				toolCallId: dispatchToolCallId,
+				messageId: yield* messageId,
+				message: userMessage('child prompt'),
+			})
+			return { childAgentId, entries: yield* readEntries }
+		}).pipe(Effect.provide(testLayer))
+
+		const projected = JSON.stringify(messagesForAgent(result.entries, result.childAgentId))
+		expect(projected).toContain('recent user')
+		expect(projected).toContain('recent assistant')
+		expect(projected).toContain('child prompt')
+		expect(projected).not.toContain('old user')
+		expect(projected).not.toContain('invoking user')
 	}),
 )
 

--- a/packages/fold-core/test/Subagents/SubagentRoster.vi.test.ts
+++ b/packages/fold-core/test/Subagents/SubagentRoster.vi.test.ts
@@ -173,7 +173,7 @@ const hostAgentTool = (forkAgent: ForkAgentDefinition) =>
 				Effect.gen(function* () {
 					const subagents = yield* Subagents
 					const result = yield* subagents
-						.fork({ prompt, skill: null, forkAgentDefinitionId: forkAgent.id })
+						.fork({ prompt, skill: null, forkAgentDefinitionId: forkAgent.id, history: 'all' })
 						.pipe(Effect.orDie)
 					return { content: renderSubagentResult(result) }
 				}),


### PR DESCRIPTION
## Summary
- add host-selectable fork history windows while preserving legacy full-prefix replay
- persist deterministic per-agent prompt cache keys and propagate them to OpenAI/Codex requests
- exclude invoking tool turns from configured fork history and cover projection/request behavior with tests

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run format:check`
- `git diff --check`