### PR TITLE
fix(fold-agent): expand home-relative working directories

### DIFF
--- a/packages/fold-agent/src/Fs/DefaultFileSystem.ts
+++ b/packages/fold-agent/src/Fs/DefaultFileSystem.ts
@@ -9,6 +9,8 @@
 import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem'
 import { Context, Effect, FileSystem, Layer } from 'effect'
 
+import { resolveToCwd } from './PathResolve'
+
 /** Options shared by every filesystem-backed tool factory in fold-agent. */
 export type FsToolOptions = {
 	/** Working directory for resolving relative paths. Defaults to `process.cwd()` at call time. */
@@ -39,4 +41,4 @@ export const fileSystemFor = (options?: FsToolOptions): FileSystem.FileSystem =>
 	options?.fileSystem ?? defaultNodeFileSystem()
 
 /** Resolve the working directory a tool handler should resolve relative paths against. */
-export const cwdFor = (options?: FsToolOptions): string => options?.cwd ?? process.cwd()
+export const cwdFor = (options?: FsToolOptions): string => resolveToCwd(options?.cwd ?? process.cwd(), process.cwd())

--- a/packages/fold-agent/src/Fs/DefaultFileSystem.ts
+++ b/packages/fold-agent/src/Fs/DefaultFileSystem.ts
@@ -9,8 +9,6 @@
 import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem'
 import { Context, Effect, FileSystem, Layer } from 'effect'
 
-import { resolveToCwd } from './PathResolve'
-
 /** Options shared by every filesystem-backed tool factory in fold-agent. */
 export type FsToolOptions = {
 	/** Working directory for resolving relative paths. Defaults to `process.cwd()` at call time. */
@@ -41,4 +39,4 @@ export const fileSystemFor = (options?: FsToolOptions): FileSystem.FileSystem =>
 	options?.fileSystem ?? defaultNodeFileSystem()
 
 /** Resolve the working directory a tool handler should resolve relative paths against. */
-export const cwdFor = (options?: FsToolOptions): string => resolveToCwd(options?.cwd ?? process.cwd(), process.cwd())
+export const cwdFor = (options?: FsToolOptions): string => options?.cwd ?? process.cwd()

--- a/packages/fold-agent/src/Fs/PathResolve.ts
+++ b/packages/fold-agent/src/Fs/PathResolve.ts
@@ -6,35 +6,31 @@
  */
 import { homedir } from 'node:os'
 
-import * as NodePath from '@effect/platform-node/NodePath'
-import { Context, Effect, type FileSystem, Layer, Path } from 'effect'
+import { Effect, type FileSystem, Path } from 'effect'
 
 const unicodeSpaces = /[  -   　]/g
 
-let nodePath: Path.Path | null = null
-
-const defaultNodePath = (): Path.Path => {
-	if (nodePath === null) {
-		nodePath = Effect.runSync(
-			Effect.scoped(Layer.build(NodePath.layer).pipe(Effect.map((context) => Context.get(context, Path.Path)))),
-		)
-	}
-
-	return nodePath
-}
-
 /** Normalize a model-supplied path and resolve it against the working directory (pi's resolvePath). */
-export const resolveToCwd = (filePath: string, cwd: string): string => {
-	const pathService = defaultNodePath()
-	let path = filePath.trim().replace(unicodeSpaces, ' ')
+export const resolveToCwd = (filePath: string, cwd: string) =>
+	Effect.gen(function* () {
+		const pathService = yield* Path.Path
+		let path = filePath.trim().replace(unicodeSpaces, ' ')
 
-	if (path.startsWith('@')) path = path.slice(1)
-	if (path.startsWith('file://')) path = Effect.runSync(pathService.fromFileUrl(new URL(path)))
-	if (path === '~') path = homedir()
-	else if (path.startsWith('~/')) path = pathService.resolve(homedir(), path.slice(2))
+		if (path.startsWith('@')) path = path.slice(1)
+		if (path.startsWith('file://')) {
+			const url = yield* Effect.try({
+				try: () => new URL(path),
+				catch: () => ({ message: `Invalid file URL: ${path}` }),
+			})
+			path = yield* pathService
+				.fromFileUrl(url)
+				.pipe(Effect.mapError(() => ({ message: `Invalid file URL: ${path}` })))
+		}
+		if (path === '~') path = homedir()
+		else if (path.startsWith('~/')) path = pathService.resolve(homedir(), path.slice(2))
 
-	return pathService.isAbsolute(path) ? pathService.normalize(path) : pathService.resolve(cwd, path)
-}
+		return pathService.isAbsolute(path) ? pathService.normalize(path) : pathService.resolve(cwd, path)
+	})
 
 /** macOS screenshot names put a narrow no-break space before AM/PM. */
 const macosScreenshotVariant = (path: string): string => path.replace(/ (AM|PM)\./gi, ' $1.')
@@ -53,9 +49,13 @@ const exists = (fs: FileSystem.FileSystem, path: string): Effect.Effect<boolean>
  * not exist: as-is, narrow-no-break-space AM/PM, NFD, curly apostrophe, NFD + curly. Returns the first
  * existing variant, or the plain resolved path when none exists (the caller surfaces the read error).
  */
-export const resolveReadPath = (filePath: string, cwd: string, fs: FileSystem.FileSystem): Effect.Effect<string> =>
+export const resolveReadPath = (
+	filePath: string,
+	cwd: string,
+	fs: FileSystem.FileSystem,
+): Effect.Effect<string, { readonly message: string }, Path.Path> =>
 	Effect.gen(function* () {
-		const resolved = resolveToCwd(filePath, cwd)
+		const resolved = yield* resolveToCwd(filePath, cwd)
 		if (yield* exists(fs, resolved)) return resolved
 
 		const variants = [

--- a/packages/fold-agent/src/Fs/PathResolve.ts
+++ b/packages/fold-agent/src/Fs/PathResolve.ts
@@ -5,23 +5,35 @@
  * curly combination - tried in that order against the filesystem.
  */
 import { homedir } from 'node:os'
-import { isAbsolute, normalize, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 
-import { Effect, type FileSystem } from 'effect'
+import * as NodePath from '@effect/platform-node/NodePath'
+import { Context, Effect, type FileSystem, Layer, Path } from 'effect'
 
 const unicodeSpaces = /[  -   　]/g
 
+let nodePath: Path.Path | null = null
+
+const defaultNodePath = (): Path.Path => {
+	if (nodePath === null) {
+		nodePath = Effect.runSync(
+			Effect.scoped(Layer.build(NodePath.layer).pipe(Effect.map((context) => Context.get(context, Path.Path)))),
+		)
+	}
+
+	return nodePath
+}
+
 /** Normalize a model-supplied path and resolve it against the working directory (pi's resolvePath). */
 export const resolveToCwd = (filePath: string, cwd: string): string => {
+	const pathService = defaultNodePath()
 	let path = filePath.trim().replace(unicodeSpaces, ' ')
 
 	if (path.startsWith('@')) path = path.slice(1)
-	if (path.startsWith('file://')) path = fileURLToPath(path)
+	if (path.startsWith('file://')) path = Effect.runSync(pathService.fromFileUrl(new URL(path)))
 	if (path === '~') path = homedir()
-	else if (path.startsWith('~/')) path = resolve(homedir(), path.slice(2))
+	else if (path.startsWith('~/')) path = pathService.resolve(homedir(), path.slice(2))
 
-	return isAbsolute(path) ? normalize(path) : resolve(cwd, path)
+	return pathService.isAbsolute(path) ? pathService.normalize(path) : pathService.resolve(cwd, path)
 }
 
 /** macOS screenshot names put a narrow no-break space before AM/PM. */

--- a/packages/fold-agent/src/Tools/ApplyPatchTool.ts
+++ b/packages/fold-agent/src/Tools/ApplyPatchTool.ts
@@ -5,19 +5,18 @@
  * write/move/delete steps while holding every target file's mutation lock. Failure messages carry the
  * `apply_patch verification failed:` prefix (opencode/agentlayer convention).
  */
-import { dirname } from 'node:path'
-
 import {
 	applyPatchToolContract,
 	computePatch,
 	defineTool,
 	parsePatch,
+	platformToolDependencies,
 	type PatchOp,
 	type FoldTool,
 } from '@humanlayer/fold-core'
-import { Effect } from 'effect'
+import { Effect, FileSystem, Path } from 'effect'
 
-import { cwdFor, fileSystemFor, type FsToolOptions } from '../Fs/DefaultFileSystem'
+import type { FsToolOptions } from '../Fs/DefaultFileSystem'
 import { withFileMutationLocks } from '../Fs/MutationQueue'
 import { resolveToCwd } from '../Fs/PathResolve'
 import { platformErrorMessage } from './ReadTool'
@@ -34,16 +33,18 @@ const opPaths = (op: PatchOp): ReadonlyArray<string> =>
 export const applyPatchTool = (options?: FsToolOptions): FoldTool =>
 	defineTool({
 		...applyPatchToolContract,
+		dependencies: platformToolDependencies,
 		handler: (params) =>
 			Effect.gen(function* () {
-				const fs = fileSystemFor(options)
-				const cwd = cwdFor(options)
+				const fs = options?.fileSystem ?? (yield* FileSystem.FileSystem)
+				const pathService = yield* Path.Path
+				const cwd = yield* resolveToCwd(options?.cwd ?? process.cwd(), process.cwd())
 				const ops = yield* parsePatch(params.patch_text).pipe(
 					Effect.mapError((error) => verificationFailed(error.message)),
 				)
 
-				const resolvePath = (path: string): string => resolveToCwd(path, cwd)
-				const touchedPaths = [...new Set(ops.flatMap(opPaths).map(resolvePath))]
+				const resolvePath = (path: string) => resolveToCwd(path, cwd)
+				const touchedPaths = [...new Set(yield* Effect.forEach(ops.flatMap(opPaths), resolvePath))]
 
 				// Hold every target's mutation lock across read-verify-write so parallel mutations of the
 				// same files cannot interleave with the patch.
@@ -56,8 +57,9 @@ export const applyPatchTool = (options?: FsToolOptions): FoldTool =>
 						for (const op of ops) {
 							if (op._tag === 'add') continue
 							if (!files.has(op.path)) {
+								const source = yield* resolvePath(op.path)
 								const content = yield* fs
-									.readFileString(resolvePath(op.path))
+									.readFileString(source)
 									.pipe(Effect.catch(() => Effect.succeed<string | null>(null)))
 								files.set(op.path, content)
 							}
@@ -71,8 +73,8 @@ export const applyPatchTool = (options?: FsToolOptions): FoldTool =>
 						for (const step of computed.steps) {
 							switch (step._tag) {
 								case 'write': {
-									const target = resolvePath(step.path)
-									yield* fs.makeDirectory(dirname(target), { recursive: true }).pipe(
+									const target = yield* resolvePath(step.path)
+									yield* fs.makeDirectory(pathService.dirname(target), { recursive: true }).pipe(
 										Effect.mapError((error) => ({
 											message: platformErrorMessage('apply_patch', step.path, error),
 										})),
@@ -86,7 +88,7 @@ export const applyPatchTool = (options?: FsToolOptions): FoldTool =>
 								}
 
 								case 'delete':
-									yield* fs.remove(resolvePath(step.path)).pipe(
+									yield* fs.remove(yield* resolvePath(step.path)).pipe(
 										Effect.mapError((error) => ({
 											message: platformErrorMessage('apply_patch', step.path, error),
 										})),
@@ -94,8 +96,8 @@ export const applyPatchTool = (options?: FsToolOptions): FoldTool =>
 									break
 
 								case 'move': {
-									const target = resolvePath(step.toPath)
-									yield* fs.makeDirectory(dirname(target), { recursive: true }).pipe(
+									const target = yield* resolvePath(step.toPath)
+									yield* fs.makeDirectory(pathService.dirname(target), { recursive: true }).pipe(
 										Effect.mapError((error) => ({
 											message: platformErrorMessage('apply_patch', step.toPath, error),
 										})),
@@ -105,7 +107,7 @@ export const applyPatchTool = (options?: FsToolOptions): FoldTool =>
 											message: platformErrorMessage('apply_patch', step.toPath, error),
 										})),
 									)
-									yield* fs.remove(resolvePath(step.fromPath)).pipe(
+									yield* fs.remove(yield* resolvePath(step.fromPath)).pipe(
 										Effect.mapError((error) => ({
 											message: platformErrorMessage('apply_patch', step.fromPath, error),
 										})),

--- a/packages/fold-agent/src/Tools/BashTool.ts
+++ b/packages/fold-agent/src/Tools/BashTool.ts
@@ -32,6 +32,7 @@ import { type Context, Duration, Effect, Fiber, Layer, Option, Random, Ref, Sche
 import { ChildProcess, type ChildProcessSpawner } from 'effect/unstable/process'
 
 import { cwdFor, fileSystemFor, type FsToolOptions } from '../Fs/DefaultFileSystem'
+import { resolveToCwd } from '../Fs/PathResolve'
 import type { OutputStoreService } from '../OutputStore/OutputStore'
 import { platformErrorMessage } from './ReadTool'
 
@@ -264,7 +265,8 @@ export const bashTool = (options?: BashToolOptions): FoldTool =>
 		handler: (params) =>
 			Effect.gen(function* () {
 				const fs = fileSystemFor(options)
-				const cwd = params.workdir ?? cwdFor(options)
+				const configuredCwd = cwdFor(options)
+				const cwd = params.workdir === undefined ? configuredCwd : resolveToCwd(params.workdir, configuredCwd)
 				const timeoutSeconds = params.timeout ?? defaultTimeoutSeconds
 
 				if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {

--- a/packages/fold-agent/src/Tools/BashTool.ts
+++ b/packages/fold-agent/src/Tools/BashTool.ts
@@ -12,26 +12,23 @@
  * failures carrying the accumulated output; signal-killed commands are successes (pi semantics).
  */
 import { homedir, tmpdir } from 'node:os'
-import { join } from 'node:path'
 
-import * as NodeChildProcessSpawner from '@effect/platform-node/NodeChildProcessSpawner'
-import * as NodeFileSystem from '@effect/platform-node/NodeFileSystem'
-import * as NodePath from '@effect/platform-node/NodePath'
 import {
 	defaultMaxBytes,
 	defineTool,
 	formatSize,
 	CurrentToolCall,
 	InterruptNote,
+	platformToolDependencies,
 	ToolEvents,
 	truncateTail,
 	utf8ByteLength,
 	type FoldTool,
 } from '@humanlayer/fold-core'
-import { type Context, Duration, Effect, Fiber, Layer, Option, Random, Ref, Schema, Semaphore, Stream } from 'effect'
-import { ChildProcess, type ChildProcessSpawner } from 'effect/unstable/process'
+import { Duration, Effect, Fiber, FileSystem, Option, Path, Random, Ref, Schema, Semaphore, Stream } from 'effect'
+import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process'
 
-import { cwdFor, fileSystemFor, type FsToolOptions } from '../Fs/DefaultFileSystem'
+import type { FsToolOptions } from '../Fs/DefaultFileSystem'
 import { resolveToCwd } from '../Fs/PathResolve'
 import type { OutputStoreService } from '../OutputStore/OutputStore'
 import { platformErrorMessage } from './ReadTool'
@@ -88,26 +85,6 @@ export type BashToolOptions = FsToolOptions & {
 	readonly spillDir?: string
 	/** Deterministic per-session output store. When absent, bash uses the legacy temp spill file. */
 	readonly outputStore?: OutputStoreService
-}
-
-let spawnerContext: Context.Context<ChildProcessSpawner.ChildProcessSpawner> | null = null
-
-/** The process-wide spawner service, built lazily once over the Node platform layers. */
-const defaultSpawner = (): Context.Context<ChildProcessSpawner.ChildProcessSpawner> => {
-	if (spawnerContext === null) {
-		spawnerContext = Effect.runSync(
-			Effect.scoped(
-				// Layer.provide keeps only the spawner in the built context; fs/path stay internal.
-				Layer.build(
-					NodeChildProcessSpawner.layer.pipe(
-						Layer.provide(Layer.mergeAll(NodeFileSystem.layer, NodePath.layer)),
-					),
-				),
-			),
-		)
-	}
-
-	return spawnerContext
 }
 
 type AccumulatorState = {
@@ -262,11 +239,15 @@ export const bashTool = (options?: BashToolOptions): FoldTool =>
 		parameters: BashParameters,
 		success: BashSuccess,
 		failure: BashFailure,
+		dependencies: platformToolDependencies,
 		handler: (params) =>
 			Effect.gen(function* () {
-				const fs = fileSystemFor(options)
-				const configuredCwd = cwdFor(options)
-				const cwd = params.workdir === undefined ? configuredCwd : resolveToCwd(params.workdir, configuredCwd)
+				const fs = options?.fileSystem ?? (yield* FileSystem.FileSystem)
+				const pathService = yield* Path.Path
+				const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+				const configuredCwd = yield* resolveToCwd(options?.cwd ?? process.cwd(), process.cwd())
+				const cwd =
+					params.workdir === undefined ? configuredCwd : yield* resolveToCwd(params.workdir, configuredCwd)
 				const timeoutSeconds = params.timeout ?? defaultTimeoutSeconds
 
 				if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
@@ -288,7 +269,8 @@ export const bashTool = (options?: BashToolOptions): FoldTool =>
 				const outputStore = options?.outputStore
 				const spillRef = outputStore?.refFor(currentToolCall.toolCallId)
 				const spillToken = `${(yield* Random.next).toString(36).slice(2)}${(yield* Random.next).toString(36).slice(2)}`
-				const spillPath = spillRef?.path ?? join(options?.spillDir ?? tmpdir(), `fold-bash-${spillToken}.log`)
+				const spillPath =
+					spillRef?.path ?? pathService.join(options?.spillDir ?? tmpdir(), `fold-bash-${spillToken}.log`)
 				const accumulator = yield* makeAccumulator({
 					spillPath,
 					writeSpill: (path, chunk) =>
@@ -346,15 +328,21 @@ export const bashTool = (options?: BashToolOptions): FoldTool =>
 					})
 
 				const run = Effect.gen(function* () {
-					const handle = yield* ChildProcess.make('bash', ['-c', params.command], {
-						cwd,
-						env: { PATH: `${join(homedir(), '.fold', 'bin')}:${process.env.PATH ?? ''}` },
-						extendEnv: true,
-					}).pipe(
-						Effect.mapError((error) => ({
-							message: `Failed to start command: ${platformErrorMessage('bash', params.command, error)}`,
-						})),
-					)
+					const handle = yield* spawner
+						.spawn(
+							ChildProcess.make('bash', ['-c', params.command], {
+								cwd,
+								env: {
+									PATH: `${pathService.join(homedir(), '.fold', 'bin')}:${process.env.PATH ?? ''}`,
+								},
+								extendEnv: true,
+							}),
+						)
+						.pipe(
+							Effect.mapError((error) => ({
+								message: `Failed to start command: ${platformErrorMessage('bash', params.command, error)}`,
+							})),
+						)
 
 					// On interruption the spawner's own finalizer only SIGTERMs the group and awaits exit;
 					// this finalizer runs first (LIFO) and adds the SIGKILL escalation so a TERM-ignoring
@@ -394,7 +382,7 @@ export const bashTool = (options?: BashToolOptions): FoldTool =>
 				})
 
 				// The scope bounds the child process; interruption triggers the escalating group kill above.
-				const outcome = yield* Effect.scoped(run).pipe(Effect.provideContext(defaultSpawner()))
+				const outcome = yield* Effect.scoped(run)
 
 				const { text, totalLines, lastLineBytes } = yield* accumulator.snapshot
 				const truncation = truncateTail(text)

--- a/packages/fold-agent/src/Tools/EditTool.ts
+++ b/packages/fold-agent/src/Tools/EditTool.ts
@@ -4,10 +4,17 @@
  * over the file's content, and a serialized read-modify-write through the per-file mutation queue so
  * parallel edits of one file cannot interleave.
  */
-import { defineTool, applyEdits, editToolContract, normalizeEditInput, type FoldTool } from '@humanlayer/fold-core'
-import { Effect } from 'effect'
+import {
+	defineTool,
+	applyEdits,
+	editToolContract,
+	normalizeEditInput,
+	platformToolDependencies,
+	type FoldTool,
+} from '@humanlayer/fold-core'
+import { Effect, FileSystem } from 'effect'
 
-import { cwdFor, fileSystemFor, type FsToolOptions } from '../Fs/DefaultFileSystem'
+import type { FsToolOptions } from '../Fs/DefaultFileSystem'
 import { withFileMutationLock } from '../Fs/MutationQueue'
 import { resolveToCwd } from '../Fs/PathResolve'
 import { errnoCode, platformErrorMessage } from './ReadTool'
@@ -16,10 +23,12 @@ import { errnoCode, platformErrorMessage } from './ReadTool'
 export const editTool = (options?: FsToolOptions): FoldTool =>
 	defineTool({
 		...editToolContract,
+		dependencies: platformToolDependencies,
 		handler: (params) =>
 			Effect.gen(function* () {
-				const fs = fileSystemFor(options)
-				const absolutePath = resolveToCwd(params.path, cwdFor(options))
+				const fs = options?.fileSystem ?? (yield* FileSystem.FileSystem)
+				const cwd = yield* resolveToCwd(options?.cwd ?? process.cwd(), process.cwd())
+				const absolutePath = yield* resolveToCwd(params.path, cwd)
 				const edits = yield* normalizeEditInput(params).pipe(
 					Effect.mapError((error) => ({ message: error.message })),
 				)

--- a/packages/fold-agent/src/Tools/ReadTool.ts
+++ b/packages/fold-agent/src/Tools/ReadTool.ts
@@ -9,15 +9,16 @@ import {
 	defineTool,
 	formatSize,
 	defaultMaxBytes,
+	platformToolDependencies,
 	readToolContract,
 	truncateHead,
 	type FoldTool,
 	type ToolResultBlock,
 } from '@humanlayer/fold-core'
-import { Effect, type PlatformError } from 'effect'
+import { Effect, FileSystem, type PlatformError } from 'effect'
 
-import { cwdFor, fileSystemFor, type FsToolOptions } from '../Fs/DefaultFileSystem'
-import { resolveReadPath } from '../Fs/PathResolve'
+import type { FsToolOptions } from '../Fs/DefaultFileSystem'
+import { resolveReadPath, resolveToCwd } from '../Fs/PathResolve'
 import { detectSupportedImageMimeType, imageSniffBytes } from './Image/Mime'
 import { processImage } from './Image/Process'
 
@@ -56,10 +57,11 @@ export const errnoCode = (error: PlatformError.PlatformError): string => {
 export const readTool = (options?: FsToolOptions): FoldTool =>
 	defineTool({
 		...readToolContract,
+		dependencies: platformToolDependencies,
 		handler: (params) =>
 			Effect.gen(function* () {
-				const fs = fileSystemFor(options)
-				const cwd = cwdFor(options)
+				const fs = options?.fileSystem ?? (yield* FileSystem.FileSystem)
+				const cwd = yield* resolveToCwd(options?.cwd ?? process.cwd(), process.cwd())
 				const absolutePath = yield* resolveReadPath(params.path, cwd, fs)
 
 				const bytes = yield* fs

--- a/packages/fold-agent/src/Tools/WriteTool.ts
+++ b/packages/fold-agent/src/Tools/WriteTool.ts
@@ -3,12 +3,16 @@
  * directory creation, serialized through the per-file mutation queue. One deliberate deviation from pi
  * (per D18): the success message reports the true UTF-8 byte count, not the UTF-16 code-unit length.
  */
-import { dirname } from 'node:path'
+import {
+	defineTool,
+	platformToolDependencies,
+	utf8ByteLength,
+	writeToolContract,
+	type FoldTool,
+} from '@humanlayer/fold-core'
+import { Effect, FileSystem, Path } from 'effect'
 
-import { defineTool, utf8ByteLength, writeToolContract, type FoldTool } from '@humanlayer/fold-core'
-import { Effect } from 'effect'
-
-import { cwdFor, fileSystemFor, type FsToolOptions } from '../Fs/DefaultFileSystem'
+import type { FsToolOptions } from '../Fs/DefaultFileSystem'
 import { withFileMutationLock } from '../Fs/MutationQueue'
 import { resolveToCwd } from '../Fs/PathResolve'
 import { platformErrorMessage } from './ReadTool'
@@ -17,16 +21,19 @@ import { platformErrorMessage } from './ReadTool'
 export const writeTool = (options?: FsToolOptions): FoldTool =>
 	defineTool({
 		...writeToolContract,
+		dependencies: platformToolDependencies,
 		handler: (params) =>
 			Effect.gen(function* () {
-				const fs = fileSystemFor(options)
-				const absolutePath = resolveToCwd(params.path, cwdFor(options))
+				const fs = options?.fileSystem ?? (yield* FileSystem.FileSystem)
+				const pathService = yield* Path.Path
+				const cwd = yield* resolveToCwd(options?.cwd ?? process.cwd(), process.cwd())
+				const absolutePath = yield* resolveToCwd(params.path, cwd)
 
 				yield* withFileMutationLock(
 					fs,
 					absolutePath,
 					Effect.gen(function* () {
-						yield* fs.makeDirectory(dirname(absolutePath), { recursive: true }).pipe(
+						yield* fs.makeDirectory(pathService.dirname(absolutePath), { recursive: true }).pipe(
 							Effect.mapError((error) => ({
 								message: platformErrorMessage('write', params.path, error),
 							})),

--- a/packages/fold-agent/test/Fs/PathResolve.vi.test.ts
+++ b/packages/fold-agent/test/Fs/PathResolve.vi.test.ts
@@ -1,12 +1,16 @@
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import * as NodePath from '@effect/platform-node/NodePath'
 import { expect, it } from '@effect/vitest'
+import { Effect } from 'effect'
 
-import { cwdFor } from '../../src/Fs/DefaultFileSystem'
+import { resolveToCwd } from '../../src/Fs/PathResolve'
 
-it('expands a home-relative configured working directory to an absolute path', () => {
-	expect(cwdFor({ cwd: '~/.humanlayer/workspaces/example' })).toBe(
-		join(homedir(), '.humanlayer', 'workspaces', 'example'),
-	)
-})
+it.effect('expands a home-relative configured working directory to an absolute path', () =>
+	Effect.gen(function* () {
+		expect(yield* resolveToCwd('~/.humanlayer/workspaces/example', process.cwd())).toBe(
+			join(homedir(), '.humanlayer', 'workspaces', 'example'),
+		)
+	}).pipe(Effect.provide(NodePath.layer)),
+)

--- a/packages/fold-agent/test/Fs/PathResolve.vi.test.ts
+++ b/packages/fold-agent/test/Fs/PathResolve.vi.test.ts
@@ -1,0 +1,12 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import { expect, it } from '@effect/vitest'
+
+import { cwdFor } from '../../src/Fs/DefaultFileSystem'
+
+it('expands a home-relative configured working directory to an absolute path', () => {
+	expect(cwdFor({ cwd: '~/.humanlayer/workspaces/example' })).toBe(
+		join(homedir(), '.humanlayer', 'workspaces', 'example'),
+	)
+})

--- a/packages/fold-agent/test/TestHelpers.ts
+++ b/packages/fold-agent/test/TestHelpers.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, normalize } from 'node:path'
 
+import * as NodeServices from '@effect/platform-node/NodeServices'
 import {
 	AgentId,
 	CurrentAgent,
@@ -36,6 +37,7 @@ export const makeAmbientServices = (): Effect.Effect<{
 
 		return {
 			layer: Layer.mergeAll(
+				NodeServices.layer,
 				Layer.succeed(ToolState, { get: () => Effect.succeed(null), set: () => Effect.void }),
 				Layer.succeed(ToolEvents, {
 					emit: (payload) => Ref.update(events, (recorded) => [...recorded, payload]),

--- a/packages/fold-agent/test/Tools/BashTool.vi.test.ts
+++ b/packages/fold-agent/test/Tools/BashTool.vi.test.ts
@@ -4,6 +4,7 @@
  * deltas, tail truncation with spill files, EPIPE-style pipelines, and input validation.
  */
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { join } from 'node:path'
 
 import { expect, it } from '@effect/vitest'
@@ -43,6 +44,22 @@ it.live('runs in the provided workdir', () =>
 		const result = yield* runHandler(handlerOf(bashTool())({ command: 'ls', workdir: dir }))
 
 		expect(outputOf(result)).toContain('marker.txt')
+	}),
+)
+
+it.live('expands a home-relative configured working directory', () =>
+	Effect.gen(function* () {
+		const result = yield* runHandler(handlerOf(bashTool({ cwd: '~' }))({ command: 'pwd' }))
+
+		expect(outputOf(result).trim()).toBe(homedir())
+	}),
+)
+
+it.live('expands a home-relative command working directory', () =>
+	Effect.gen(function* () {
+		const result = yield* runHandler(handlerOf(bashTool())({ command: 'pwd', workdir: '~' }))
+
+		expect(outputOf(result).trim()).toBe(homedir())
 	}),
 )
 

--- a/packages/fold-core/src/Api/ToolDefinition.ts
+++ b/packages/fold-core/src/Api/ToolDefinition.ts
@@ -11,8 +11,9 @@
  * scan into its description and contributes the skills prompt block - do real work in theirs. Sharing
  * the same value across several agents' `tools` arrays shares one init (one scan, one snapshot).
  */
-import { Effect, Schema } from 'effect'
+import { Effect, FileSystem, Path, Schema } from 'effect'
 import { Tool } from 'effect/unstable/ai'
+import { ChildProcessSpawner } from 'effect/unstable/process'
 
 import type { SkillSourceService } from '../Skills/SkillSource'
 import { Subagents } from '../Subagents/SubagentsService'
@@ -41,6 +42,15 @@ export type ToolHandlerServices =
 	| CurrentToolCall
 	| InterruptNote
 	| Subagents
+
+type PlatformToolServices = FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+
+/** Neutral platform services used by filesystem and process-backed tools. */
+export const platformToolDependencies = [
+	FileSystem.FileSystem,
+	Path.Path,
+	ChildProcessSpawner.ChildProcessSpawner,
+] as const
 
 /** Handler stored on a tool descriptor, erased to the runtime dispatch shape. */
 export type ErasedToolHandler = (params: unknown) => Effect.Effect<unknown, unknown, ToolHandlerServices>
@@ -90,7 +100,10 @@ export type DefineToolOptions<Params extends Schema.Top, Success extends Schema.
 	readonly success?: Success
 	/** Failure schema for expected, model-visible failures. Defaults to never (handler cannot fail). */
 	readonly failure?: Failure
-	readonly handler: (params: Params['Type']) => Effect.Effect<Success['Type'], Failure['Type'], ToolHandlerServices>
+	readonly dependencies?: typeof platformToolDependencies
+	readonly handler: (
+		params: Params['Type'],
+	) => Effect.Effect<Success['Type'], Failure['Type'], ToolHandlerServices | PlatformToolServices>
 }
 
 /**
@@ -121,14 +134,28 @@ export const defineTool = <
 		failureMode: 'return',
 		// Every tool may use the ambient per-call services; declaring them here keeps handler `R`
 		// honest while the runtime provides all of them around each execution.
-		dependencies: [ToolState, ToolEvents, StopController, CurrentAgent, CurrentToolCall, InterruptNote, Subagents],
+		dependencies: [
+			ToolState,
+			ToolEvents,
+			StopController,
+			CurrentAgent,
+			CurrentToolCall,
+			InterruptNote,
+			Subagents,
+			...(options.dependencies ?? []),
+		],
 	}).annotate(Tool.Strict, false)
 
 	// asVoid yields the undefined value at runtime, which is exactly what Schema.Undefined encodes.
-	const handler =
+	const handlerWithDependencies =
 		options.success === undefined
 			? (params: Params['Type']) => options.handler(params).pipe(Effect.asVoid)
 			: options.handler
+	// SAFETY: Effect AI supplies the services declared by `dependencies` before invoking this handler.
+	// The erased Fold dispatch table retains only Fold's per-call services because heterogeneous tools
+	// cannot preserve their individual dependency rows after collection.
+	// oxlint-disable-next-line typescript/consistent-type-assertions
+	const handler = handlerWithDependencies as ErasedToolHandler
 
 	return {
 		name: options.name,


### PR DESCRIPTION
## Summary
- normalize configured coding-tool working directories through Fold's shared path resolver
- use Effect's `Path` contract with the Node platform implementation instead of direct Node path helpers
- expand home-relative Bash `workdir` values and cover the Riptide `~/.humanlayer/workspaces/...` regression

## Verification
- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run format:check`
- `git diff --check`