### PR TITLE
Expose post-tool execution context

### DIFF
--- a/packages/fold-core/src/HookRunner/Schema.ts
+++ b/packages/fold-core/src/HookRunner/Schema.ts
@@ -70,6 +70,9 @@ export const PostToolUseHookInput = Schema.Struct({
 	parentAgentId: Schema.NullOr(AgentId),
 	toolCallId: ToolCallId,
 	toolName: Schema.String,
+	originalInput: Schema.Unknown,
+	executedInput: Schema.Unknown,
+	handlerResult: Schema.Unknown,
 	result: Schema.Unknown,
 	isFailure: Schema.Boolean,
 }).annotate({ identifier: 'PostToolUseHookInput' })

--- a/packages/fold-core/src/ToolRuntime/ToolRuntimeLayer.ts
+++ b/packages/fold-core/src/ToolRuntime/ToolRuntimeLayer.ts
@@ -349,6 +349,8 @@ const finalOutputAfterPostToolHooks = (input: {
 	readonly parentAgentId: AgentId | null
 	readonly toolCallId: ToolCallId
 	readonly toolName: string
+	readonly originalInput: unknown
+	readonly executedInput: unknown
 	readonly output: FinalToolOutput
 }): Effect.Effect<FinalToolOutput, HookExecutionError, HookRunner | StopController> =>
 	Effect.gen(function* () {
@@ -360,6 +362,9 @@ const finalOutputAfterPostToolHooks = (input: {
 			parentAgentId: input.parentAgentId,
 			toolCallId: input.toolCallId,
 			toolName: input.toolName,
+			originalInput: input.originalInput,
+			executedInput: input.executedInput,
+			handlerResult: input.output.result,
 			result: input.output.result,
 			isFailure: input.output.isFailure,
 		})
@@ -458,6 +463,8 @@ const settlePreparedToolCall = (input: {
 				parentAgentId: input.parentAgentId,
 				toolCallId,
 				toolName,
+				originalInput: input.prepared.original.params,
+				executedInput: input.prepared.params,
 				output: handlerOutput,
 			})
 

--- a/packages/fold-core/test/HookRunner/PassThrough.vi.test.ts
+++ b/packages/fold-core/test/HookRunner/PassThrough.vi.test.ts
@@ -48,6 +48,9 @@ it.effect('layerNoHooks returns pass-through decisions', () =>
 			parentAgentId: null,
 			toolCallId,
 			toolName: 'echo',
+			originalInput: params,
+			executedInput: params,
+			handlerResult: { echoed: 'hello' },
 			result: { echoed: 'hello' },
 			isFailure: false,
 		})

--- a/packages/fold-core/test/HookRunner/PostToolUseHook.vi.test.ts
+++ b/packages/fold-core/test/HookRunner/PostToolUseHook.vi.test.ts
@@ -34,6 +34,9 @@ describe('HookRunner postToolUse hooks', () => {
 						parentAgentId: null,
 						toolCallId: ToolCallId.create(),
 						toolName: 'echo',
+						originalInput: { text: 'original' },
+						executedInput: { text: 'executed' },
+						handlerResult: { step: 0 },
 						result: { step: 0 },
 						isFailure: false,
 					})
@@ -71,6 +74,9 @@ describe('HookRunner postToolUse hooks', () => {
 						parentAgentId: null,
 						toolCallId: ToolCallId.create(),
 						toolName: 'echo',
+						originalInput: { text: 'original' },
+						executedInput: { text: 'executed' },
+						handlerResult: { original: true },
 						result: { original: true },
 						isFailure: false,
 					})
@@ -112,6 +118,9 @@ describe('HookRunner postToolUse hooks', () => {
 						parentAgentId: null,
 						toolCallId: ToolCallId.create(),
 						toolName: 'echo',
+						originalInput: { text: 'original' },
+						executedInput: { text: 'executed' },
+						handlerResult: { original: true },
 						result: { original: true },
 						isFailure: false,
 					})

--- a/packages/fold-core/test/ToolRuntime/ToolRuntimeLiveHooks.vi.test.ts
+++ b/packages/fold-core/test/ToolRuntime/ToolRuntimeLiveHooks.vi.test.ts
@@ -103,3 +103,62 @@ it.effect('live preToolUse hook can update execution params without changing pro
 		expect(projectedToolResult).not.toHaveProperty('executedInput')
 	}),
 )
+
+it.effect('postToolUse receives original, executed, and handler values while hooks compose in order', () =>
+	Effect.gen(function* () {
+		const recorder = yield* makeEchoRecorder()
+		const observed = yield* Ref.make<ReadonlyArray<unknown>>([])
+		const hookLayer = makeHookRunner({
+			preToolUse: [
+				{
+					name: 'mutate-echo',
+					tools: ['echo'],
+					handler: () => Effect.succeed({ _tag: 'continue' as const, params: { text: 'executed' } }),
+				},
+			],
+			postToolUse: [
+				{
+					name: 'decorate-echo',
+					tools: ['echo'],
+					handler: (input) =>
+						Ref.update(observed, (values) => [...values, input]).pipe(
+							Effect.as({ _tag: 'replace' as const, result: { decorated: true }, isFailure: false }),
+						),
+				},
+				{
+					name: 'observe-decorated-echo',
+					tools: ['echo'],
+					handler: (input) =>
+						Ref.update(observed, (values) => [...values, input]).pipe(Effect.as({ _tag: 'keep' as const })),
+				},
+			],
+		})
+		const layer = toolRuntimeBaseLayer(hookLayer, layerEchoTool(recorder))
+
+		const settlement = yield* Effect.gen(function* () {
+			const runtime = yield* ToolRuntime
+			return yield* runtime.settle({
+				agentId,
+				parentAgentId: null,
+				assistantMessage: makeAssistantToolCall({ text: 'original' }),
+			})
+		}).pipe(Effect.provide(layer))
+
+		const calls = yield* Ref.get(observed)
+		expect(calls).toHaveLength(2)
+		expect(calls[0]).toMatchObject({
+			originalInput: { text: 'original' },
+			executedInput: { text: 'executed' },
+			handlerResult: { echoed: 'executed' },
+			result: { echoed: 'executed' },
+		})
+		expect(calls[1]).toMatchObject({
+			originalInput: { text: 'original' },
+			executedInput: { text: 'executed' },
+			handlerResult: { echoed: 'executed' },
+			result: { decorated: true },
+		})
+		expect(settlement.toolResults[0]?.executedInput).toEqual({ text: 'executed' })
+		expect(settlement.toolResults[0]?.message.content[0]).toMatchObject({ result: { decorated: true } })
+	}),
+)


### PR DESCRIPTION
## Summary
- expose model-supplied and post-transform tool inputs to post-tool hooks
- preserve the raw handler result separately from results replaced by earlier hooks
- add runtime coverage for transformed inputs, hook ordering, and persisted executed input

## Why
Riptide artifact and workflow integrations need to know both what the model requested and what the tool actually executed. Keeping the handler result separate also lets best-effort product hooks preserve successful tool output when a later integration fails.

## Verification
- bun run typecheck
- bun run lint (existing warnings only)
- bun run format:check
- bun run test