### PR TITLE
Pass host environment to Fold Bash subprocesses

### DIFF
--- a/packages/fold-agent/src/Tools/BashTool.ts
+++ b/packages/fold-agent/src/Tools/BashTool.ts
@@ -85,6 +85,8 @@ export type BashToolOptions = FsToolOptions & {
 	readonly spillDir?: string
 	/** Deterministic per-session output store. When absent, bash uses the legacy temp spill file. */
 	readonly outputStore?: OutputStoreService
+	/** Environment entries inherited by every Bash subprocess created by this tool. */
+	readonly processEnvironment?: Readonly<Record<string, string>>
 }
 
 type AccumulatorState = {
@@ -328,12 +330,14 @@ export const bashTool = (options?: BashToolOptions): FoldTool =>
 					})
 
 				const run = Effect.gen(function* () {
+					const inheritedPath = options?.processEnvironment?.PATH ?? process.env.PATH ?? ''
 					const handle = yield* spawner
 						.spawn(
 							ChildProcess.make('bash', ['-c', params.command], {
 								cwd,
 								env: {
-									PATH: `${pathService.join(homedir(), '.fold', 'bin')}:${process.env.PATH ?? ''}`,
+									...options?.processEnvironment,
+									PATH: `${pathService.join(homedir(), '.fold', 'bin')}:${inheritedPath}`,
 								},
 								extendEnv: true,
 							}),

--- a/packages/fold-agent/src/Tools/CodingTools.ts
+++ b/packages/fold-agent/src/Tools/CodingTools.ts
@@ -14,8 +14,10 @@ import { readTool } from './ReadTool'
 import { webTools, type WebToolsOptions } from './WebTools'
 import { writeTool } from './WriteTool'
 
-/** Options for {@link codingTools}: the shared filesystem seam plus bash output-spill configuration. */
-export type CodingToolsOptions = FsToolOptions & Pick<BashToolOptions, 'spillDir' | 'outputStore'> & WebToolsOptions
+/** Options for {@link codingTools}: the shared filesystem seam plus Bash process configuration. */
+export type CodingToolsOptions = FsToolOptions &
+	Pick<BashToolOptions, 'spillDir' | 'outputStore' | 'processEnvironment'> &
+	WebToolsOptions
 
 /**
  * The standard coding toolset: read, write, edit, apply_patch, bash, and web tools. The model-family policy decides

--- a/packages/fold-agent/test/Tools/BashTool.vi.test.ts
+++ b/packages/fold-agent/test/Tools/BashTool.vi.test.ts
@@ -11,7 +11,7 @@ import { expect, it } from '@effect/vitest'
 import { SessionId, ToolCallId } from '@humanlayer/fold-core'
 import { Duration, Effect, Fiber } from 'effect'
 
-import { bashTool, decodeBashOutputDelta, makeOutputStore, toolOutputPathFor } from '../../src/index'
+import { bashTool, codingTools, decodeBashOutputDelta, makeOutputStore, toolOutputPathFor } from '../../src/index'
 import { handlerOf, makeAmbientServices, messageOf, outputOf, runHandler, tempDir } from '../TestHelpers'
 
 it.live('captures stdout and reports success on exit 0', () =>
@@ -20,6 +20,40 @@ it.live('captures stdout and reports success on exit 0', () =>
 		const result = yield* runHandler(handlerOf(bashTool({ cwd: dir }))({ command: 'echo hello fold' }))
 
 		expect(outputOf(result)).toBe('hello fold\n')
+	}),
+)
+
+it.live('passes host-provided session environment to Bash subprocesses', () =>
+	Effect.gen(function* () {
+		const dir = yield* tempDir
+		const result = yield* runHandler(
+			handlerOf(
+				bashTool({
+					cwd: dir,
+					processEnvironment: {
+						HUMANLAYER_SESSION_ID: 'session-from-host',
+						HUMANLAYER_SESSION_EXPIRES: '4102444800000',
+					},
+				}),
+			)({ command: 'printf "%s:%s" "$HUMANLAYER_SESSION_ID" "$HUMANLAYER_SESSION_EXPIRES"' }),
+		)
+
+		expect(outputOf(result)).toBe('session-from-host:4102444800000')
+	}),
+)
+
+it.live('forwards host-provided session environment through codingTools', () =>
+	Effect.gen(function* () {
+		const dir = yield* tempDir
+		const bash = codingTools({
+			cwd: dir,
+			processEnvironment: { HUMANLAYER_SESSION_ID: 'coding-tools-session' },
+		}).find((tool) => tool.name === 'bash')
+		if (bash === undefined) throw new Error('expected codingTools to include Bash')
+
+		const result = yield* runHandler(handlerOf(bash)({ command: 'printf "%s" "$HUMANLAYER_SESSION_ID"' }))
+
+		expect(outputOf(result)).toBe('coding-tools-session')
 	}),
 )
 


### PR DESCRIPTION
## Summary
- add a host-provided `processEnvironment` option to Fold's Bash tool
- forward the option through `codingTools` so embedding hosts can configure every session subprocess
- preserve Fold's managed-bin PATH prefix while honoring a host-provided PATH
- verify direct Bash and `codingTools` environment propagation with real subprocess tests

## Why
Riptide commit attribution installs per-session Git hook configuration through environment variables. Fold embedding hosts need a session-scoped environment seam so commits created by Bash subprocesses inherit that attribution configuration.

## Verification
- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run format:check`